### PR TITLE
Add MIA/NYC contracts to local tests

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -7,6 +7,18 @@ costs_version = 2
 
 # cities
 
+[contracts.miamicoin-auth]
+path = "contracts/cities/mia/local/miamicoin-auth.clar"
+depends_on = ["citycoin-core-trait", "citycoin-token-trait"]
+
+[contracts.miamicoin-core-v1]
+path = "contracts/cities/mia/local/miamicoin-core-v1.clar"
+depends_on = ["miamicoin-auth", "miamicoin-token", "citycoin-vrf", "citycoin-core-trait"]
+
+[contracts.miamicoin-token]
+path = "contracts/cities/mia/local/miamicoin-token.clar"
+depends_on = ["sip-010-trait", "miamicoin-auth", "citycoin-token-trait"]
+
 # core
 
 [contracts.citycoin-core-trait]

--- a/contracts/cities/mia/local/miamicoin-auth.clar
+++ b/contracts/cities/mia/local/miamicoin-auth.clar
@@ -1,0 +1,626 @@
+;; CITYCOIN AUTH CONTRACT
+
+(define-constant CONTRACT_OWNER tx-sender)
+
+;; TRAIT DEFINITIONS
+
+(use-trait coreTrait .citycoin-core-trait.citycoin-core)
+(use-trait tokenTrait .citycoin-token-trait.citycoin-token)
+
+;; ERRORS
+
+(define-constant ERR_UNKNOWN_JOB (err u6000))
+(define-constant ERR_UNAUTHORIZED (err u6001))
+(define-constant ERR_JOB_IS_ACTIVE (err u6002))
+(define-constant ERR_JOB_IS_NOT_ACTIVE (err u6003))
+(define-constant ERR_ALREADY_VOTED_THIS_WAY (err u6004))
+(define-constant ERR_JOB_IS_EXECUTED (err u6005))
+(define-constant ERR_JOB_IS_NOT_APPROVED (err u6006))
+(define-constant ERR_ARGUMENT_ALREADY_EXISTS (err u6007))
+(define-constant ERR_NO_ACTIVE_CORE_CONTRACT (err u6008))
+(define-constant ERR_CORE_CONTRACT_NOT_FOUND (err u6009))
+(define-constant ERR_UNKNOWN_ARGUMENT (err u6010))
+(define-constant ERR_INCORRECT_CONTRACT_STATE (err u6011))
+(define-constant ERR_CONTRACT_ALREADY_EXISTS (err u6012))
+
+;; JOB MANAGEMENT
+
+(define-constant REQUIRED_APPROVALS u3)
+
+(define-data-var lastJobId uint u0)
+
+(define-map Jobs
+  uint
+  {
+    creator: principal,
+    name: (string-ascii 255),
+    target: principal,
+    approvals: uint,
+    disapprovals: uint,
+    isActive: bool,
+    isExecuted: bool
+  }
+)
+
+(define-map JobApprovers
+  { jobId: uint, approver: principal }
+  bool
+)
+
+(define-map Approvers
+  principal
+  bool
+)
+
+(define-map ArgumentLastIdsByType
+  { jobId: uint, argumentType: (string-ascii 25) }
+  uint
+)
+
+(define-map UIntArgumentsByName
+  { jobId: uint, argumentName: (string-ascii 255) }
+  { argumentId: uint, value: uint}
+)
+
+(define-map UIntArgumentsById
+  { jobId: uint, argumentId: uint }
+  { argumentName: (string-ascii 255), value: uint }
+)
+
+(define-map PrincipalArgumentsByName
+  { jobId: uint, argumentName: (string-ascii 255) }
+  { argumentId: uint, value: principal }
+)
+
+(define-map PrincipalArgumentsById
+  { jobId: uint, argumentId: uint }
+  { argumentName: (string-ascii 255), value: principal }
+)
+
+;; FUNCTIONS
+
+(define-read-only (get-last-job-id)
+  (var-get lastJobId)
+)
+
+(define-public (create-job (name (string-ascii 255)) (target principal))
+  (let
+    (
+      (newJobId (+ (var-get lastJobId) u1))
+    )
+    (asserts! (is-approver tx-sender) ERR_UNAUTHORIZED)
+    (map-set Jobs
+      newJobId
+      {
+        creator: tx-sender,
+        name: name,
+        target: target,
+        approvals: u0,
+        disapprovals: u0,
+        isActive: false,
+        isExecuted: false
+      }
+    )
+    (var-set lastJobId newJobId)
+    (ok newJobId)
+  )
+)
+
+(define-read-only (get-job (jobId uint))
+  (map-get? Jobs jobId)
+)
+
+(define-public (activate-job (jobId uint))
+  (let
+    (
+      (job (unwrap! (get-job jobId) ERR_UNKNOWN_JOB))
+    )
+    (asserts! (is-eq (get creator job) tx-sender) ERR_UNAUTHORIZED)
+    (asserts! (not (get isActive job)) ERR_JOB_IS_ACTIVE)
+    (map-set Jobs 
+      jobId
+      (merge job { isActive: true })
+    )
+    (ok true)
+  )
+)
+
+(define-public (approve-job (jobId uint))
+  (let
+    (
+      (job (unwrap! (get-job jobId) ERR_UNKNOWN_JOB))
+      (previousVote (map-get? JobApprovers { jobId: jobId, approver: tx-sender }))
+    )
+    (asserts! (get isActive job) ERR_JOB_IS_NOT_ACTIVE)
+    (asserts! (is-approver tx-sender) ERR_UNAUTHORIZED)
+    ;; save vote
+    (map-set JobApprovers
+      { jobId: jobId, approver: tx-sender }
+      true
+    )
+    (match previousVote approved
+      (begin
+        (asserts! (not approved) ERR_ALREADY_VOTED_THIS_WAY)
+        (map-set Jobs jobId
+          (merge job 
+            {
+              approvals: (+ (get approvals job) u1),
+              disapprovals: (- (get disapprovals job) u1)
+            }
+          )
+        )
+      )
+      ;; no previous vote
+      (map-set Jobs
+        jobId
+        (merge job { approvals: (+ (get approvals job) u1) } )
+      )
+    )  
+    (ok true)
+  )
+)
+
+(define-public (disapprove-job (jobId uint))
+  (let
+    (
+      (job (unwrap! (get-job jobId) ERR_UNKNOWN_JOB))
+      (previousVote (map-get? JobApprovers { jobId: jobId, approver: tx-sender }))
+    )
+    (asserts! (get isActive job) ERR_JOB_IS_NOT_ACTIVE)
+    (asserts! (is-approver tx-sender) ERR_UNAUTHORIZED)
+    ;; save vote
+    (map-set JobApprovers
+      { jobId: jobId, approver: tx-sender }
+      false
+    )
+    (match previousVote approved
+      (begin
+        (asserts! approved ERR_ALREADY_VOTED_THIS_WAY)
+        (map-set Jobs jobId
+          (merge job 
+            {
+              approvals: (- (get approvals job) u1),
+              disapprovals: (+ (get disapprovals job) u1)
+            }
+          )
+        )
+      )
+      ;; no previous vote
+      (map-set Jobs
+        jobId
+        (merge job { disapprovals: (+ (get disapprovals job) u1) } )
+      )
+    )
+    (ok true)
+  )
+)
+
+(define-read-only (is-job-approved (jobId uint))
+  (match (get-job jobId) job
+    (>= (get approvals job) REQUIRED_APPROVALS)
+    false
+  )
+)
+
+(define-public (mark-job-as-executed (jobId uint))
+  (let
+    (
+      (job (unwrap! (get-job jobId) ERR_UNKNOWN_JOB))
+    )
+    (asserts! (get isActive job) ERR_JOB_IS_NOT_ACTIVE)
+    (asserts! (>= (get approvals job) REQUIRED_APPROVALS) ERR_JOB_IS_NOT_APPROVED)
+    (asserts! (is-eq (get target job) contract-caller) ERR_UNAUTHORIZED)
+    (asserts! (not (get isExecuted job)) ERR_JOB_IS_EXECUTED)
+    (map-set Jobs
+      jobId
+      (merge job { isExecuted: true })
+    )
+    (ok true)
+  )
+)
+
+(define-public (add-uint-argument (jobId uint) (argumentName (string-ascii 255)) (value uint))
+  (let
+    (
+      (argumentId (generate-argument-id jobId "uint"))
+    )
+    (try! (guard-add-argument jobId))
+    (asserts! 
+      (and
+        (map-insert UIntArgumentsById
+          { jobId: jobId, argumentId: argumentId }
+          { argumentName: argumentName, value: value }
+        )
+        (map-insert UIntArgumentsByName
+          { jobId: jobId, argumentName: argumentName }
+          { argumentId: argumentId, value: value}
+        )
+      ) 
+      ERR_ARGUMENT_ALREADY_EXISTS
+    )
+    (ok true)
+  )
+)
+
+(define-read-only (get-uint-argument-by-name (jobId uint) (argumentName (string-ascii 255)))
+  (map-get? UIntArgumentsByName { jobId: jobId, argumentName: argumentName })
+)
+
+(define-read-only (get-uint-argument-by-id (jobId uint) (argumentId uint))
+  (map-get? UIntArgumentsById { jobId: jobId, argumentId: argumentId })
+)
+
+(define-read-only (get-uint-value-by-name (jobId uint) (argumentName (string-ascii 255)))
+  (get value (get-uint-argument-by-name jobId argumentName))
+)
+
+(define-read-only (get-uint-value-by-id (jobId uint) (argumentId uint))
+  (get value (get-uint-argument-by-id jobId argumentId))
+)
+
+(define-public (add-principal-argument (jobId uint) (argumentName (string-ascii 255)) (value principal))
+  (let
+    (
+      (argumentId (generate-argument-id jobId "principal"))
+    )
+    (try! (guard-add-argument jobId))
+    (asserts! 
+      (and
+        (map-insert PrincipalArgumentsById
+          { jobId: jobId, argumentId: argumentId }
+          { argumentName: argumentName, value: value }
+        )
+        (map-insert PrincipalArgumentsByName
+          { jobId: jobId, argumentName: argumentName }
+          { argumentId: argumentId, value: value}
+        )
+      ) 
+      ERR_ARGUMENT_ALREADY_EXISTS
+    )
+    (ok true)
+  )
+)
+
+(define-read-only (get-principal-argument-by-name (jobId uint) (argumentName (string-ascii 255)))
+  (map-get? PrincipalArgumentsByName { jobId: jobId, argumentName: argumentName })
+)
+
+(define-read-only (get-principal-argument-by-id (jobId uint) (argumentId uint))
+  (map-get? PrincipalArgumentsById { jobId: jobId, argumentId: argumentId })
+)
+
+(define-read-only (get-principal-value-by-name (jobId uint) (argumentName (string-ascii 255)))
+  (get value (get-principal-argument-by-name jobId argumentName))
+)
+
+(define-read-only (get-principal-value-by-id (jobId uint) (argumentId uint))
+  (get value (get-principal-argument-by-id jobId argumentId))
+)
+
+;; PRIVATE FUNCTIONS
+
+(define-read-only  (is-approver (user principal))
+  (default-to false (map-get? Approvers user))
+)
+
+(define-private (generate-argument-id (jobId uint) (argumentType (string-ascii 25)))
+  (let
+    (
+      (argumentId (+ (default-to u0 (map-get? ArgumentLastIdsByType { jobId: jobId, argumentType: argumentType })) u1))
+    )
+    (map-set ArgumentLastIdsByType
+      { jobId: jobId, argumentType: argumentType }
+      argumentId
+    )
+    ;; return
+    argumentId
+  )
+)
+
+(define-private (guard-add-argument (jobId uint))
+  (let
+    (
+      (job (unwrap! (get-job jobId) ERR_UNKNOWN_JOB))
+    )
+    (asserts! (not (get isActive job)) ERR_JOB_IS_ACTIVE)
+    (asserts! (is-eq (get creator job) contract-caller) ERR_UNAUTHORIZED)
+    (ok true)
+  )
+)
+
+;; CONTRACT MANAGEMENT
+
+;; initial value for active core contract
+;; set to deployer address at startup to prevent
+;; circular dependency of core on auth
+(define-data-var activeCoreContract principal CONTRACT_OWNER)
+(define-data-var initialized bool false)
+
+;; core contract states
+(define-constant STATE_DEPLOYED u0)
+(define-constant STATE_ACTIVE u1)
+(define-constant STATE_INACTIVE u2)
+
+;; core contract map
+(define-map CoreContracts
+  principal
+  {
+    state: uint, 
+    startHeight: uint,
+    endHeight: uint
+  }
+)
+
+;; getter for active core contract
+(define-read-only (get-active-core-contract)
+  (begin
+    (asserts! (not (is-eq (var-get activeCoreContract) CONTRACT_OWNER)) ERR_NO_ACTIVE_CORE_CONTRACT)
+    (ok (var-get activeCoreContract))
+  )
+)
+
+;; getter for core contract map
+(define-read-only (get-core-contract-info (targetContract principal))
+  (let
+    (
+      (coreContract (unwrap! (map-get? CoreContracts targetContract) ERR_CORE_CONTRACT_NOT_FOUND))
+    )
+    (ok coreContract)
+  )
+)
+
+;; one-time function to initialize contracts after all contracts are deployed
+;; - check that deployer is calling this function
+;; - check this contract is not activated already (one-time use)
+;; - set initial map value for core contract v1
+;; - set cityWallet in core contract
+;; - set intialized true
+(define-public (initialize-contracts (coreContract <coreTrait>))
+  (let
+    (
+      (coreContractAddress (contract-of coreContract))
+    )
+    (asserts! (is-eq contract-caller CONTRACT_OWNER) ERR_UNAUTHORIZED)
+    (asserts! (not (var-get initialized)) ERR_UNAUTHORIZED)
+    (map-set CoreContracts
+      coreContractAddress
+      {
+        state: STATE_DEPLOYED,
+        startHeight: u0,
+        endHeight: u0
+      })
+    (try! (contract-call? coreContract set-city-wallet (var-get cityWallet)))
+    (var-set initialized true)
+    (ok true)
+  )
+)
+
+(define-read-only (is-initialized)
+  (var-get initialized)
+)
+
+;; function to activate core contract through registration
+;; - check that target is in core contract map
+;; - check that caller is core contract
+;; - check that target is in STATE_DEPLOYED
+;; - set active in core contract map
+;; - set as activeCoreContract
+(define-public (activate-core-contract (targetContract principal) (stacksHeight uint))
+  (let
+    (
+      (coreContract (unwrap! (map-get? CoreContracts targetContract) ERR_CORE_CONTRACT_NOT_FOUND))
+    )
+    (asserts! (is-eq (get state coreContract) STATE_DEPLOYED) ERR_INCORRECT_CONTRACT_STATE)
+    (asserts! (is-eq contract-caller targetContract) ERR_UNAUTHORIZED)
+    (map-set CoreContracts
+      targetContract
+      {
+        state: STATE_ACTIVE,
+        startHeight: stacksHeight,
+        endHeight: u0
+      })
+    (var-set activeCoreContract targetContract)
+    (ok true)
+  )
+)
+
+;; protected function to update core contract
+(define-public (upgrade-core-contract (oldContract <coreTrait>) (newContract <coreTrait>))
+  (let
+    (
+      (oldContractAddress (contract-of oldContract))
+      (oldContractMap (unwrap! (map-get? CoreContracts oldContractAddress) ERR_CORE_CONTRACT_NOT_FOUND))
+      (newContractAddress (contract-of newContract))
+    )
+    (asserts! (not (is-eq oldContractAddress newContractAddress)) ERR_CONTRACT_ALREADY_EXISTS)
+    (asserts! (is-none (map-get? CoreContracts newContractAddress)) ERR_CONTRACT_ALREADY_EXISTS)
+    (asserts! (is-authorized-city) ERR_UNAUTHORIZED)
+    (map-set CoreContracts
+      oldContractAddress
+      {
+        state: STATE_INACTIVE,
+        startHeight: (get startHeight oldContractMap),
+        endHeight: block-height
+      })
+    (map-set CoreContracts
+      newContractAddress
+      {
+        state: STATE_DEPLOYED,
+        startHeight: u0,
+        endHeight: u0
+      })
+    (var-set activeCoreContract newContractAddress)
+    (try! (contract-call? oldContract shutdown-contract block-height))
+    (try! (contract-call? newContract set-city-wallet (var-get cityWallet)))
+    (ok true)
+  )
+)
+
+(define-public (execute-upgrade-core-contract-job (jobId uint) (oldContract <coreTrait>) (newContract <coreTrait>))
+  (let
+    (
+      (oldContractArg (unwrap! (get-principal-value-by-name jobId "oldContract") ERR_UNKNOWN_ARGUMENT))
+      (newContractArg (unwrap! (get-principal-value-by-name jobId "newContract") ERR_UNKNOWN_ARGUMENT))
+      (oldContractAddress (contract-of oldContract))
+      (oldContractMap (unwrap! (map-get? CoreContracts oldContractAddress) ERR_CORE_CONTRACT_NOT_FOUND))
+      (newContractAddress (contract-of newContract))
+    )
+    (asserts! (is-approver contract-caller) ERR_UNAUTHORIZED)
+    (asserts! (and (is-eq oldContractArg oldContractAddress) (is-eq newContractArg newContractAddress)) ERR_UNAUTHORIZED)
+    (asserts! (not (is-eq oldContractAddress newContractAddress)) ERR_CONTRACT_ALREADY_EXISTS)
+    (asserts! (is-none (map-get? CoreContracts newContractAddress)) ERR_CONTRACT_ALREADY_EXISTS)
+    (map-set CoreContracts
+      oldContractAddress
+      {
+        state: STATE_INACTIVE,
+        startHeight: (get startHeight oldContractMap),
+        endHeight: block-height
+      })
+    (map-set CoreContracts
+      newContractAddress
+      {
+        state: STATE_DEPLOYED,
+        startHeight: u0,
+        endHeight: u0
+      })
+    (var-set activeCoreContract newContractAddress)
+    (try! (contract-call? oldContract shutdown-contract block-height))
+    (try! (contract-call? newContract set-city-wallet (var-get cityWallet)))
+    (as-contract (mark-job-as-executed jobId))
+  )
+)
+
+;; CITY WALLET MANAGEMENT
+
+;; initial value for city wallet
+(define-data-var cityWallet principal 'STFCVYY1RJDNJHST7RRTPACYHVJQDJ7R1DWTQHQA)
+
+;; returns city wallet principal
+(define-read-only (get-city-wallet)
+  (ok (var-get cityWallet))
+)
+ 
+;; protected function to update city wallet variable
+(define-public (set-city-wallet (targetContract <coreTrait>) (newCityWallet principal))
+  (let
+    (
+      (coreContractAddress (contract-of targetContract))
+      (coreContract (unwrap! (map-get? CoreContracts coreContractAddress) ERR_CORE_CONTRACT_NOT_FOUND))
+    )
+    (asserts! (is-authorized-city) ERR_UNAUTHORIZED)
+    (asserts! (is-eq coreContractAddress (var-get activeCoreContract)) ERR_UNAUTHORIZED)
+    (var-set cityWallet newCityWallet)
+    (try! (contract-call? targetContract set-city-wallet newCityWallet))
+    (ok true)
+  )
+)
+
+(define-public (execute-set-city-wallet-job (jobId uint) (targetContract <coreTrait>))
+  (let
+    (
+      (coreContractAddress (contract-of targetContract))
+      (coreContract (unwrap! (map-get? CoreContracts coreContractAddress) ERR_CORE_CONTRACT_NOT_FOUND))
+      (newCityWallet (unwrap! (get-principal-value-by-name jobId "newCityWallet") ERR_UNKNOWN_ARGUMENT))
+    )
+    (asserts! (is-approver contract-caller) ERR_UNAUTHORIZED)
+    (asserts! (is-eq coreContractAddress (var-get activeCoreContract)) ERR_UNAUTHORIZED)
+    (var-set cityWallet newCityWallet)
+    (try! (contract-call? targetContract set-city-wallet newCityWallet))
+    (as-contract (mark-job-as-executed jobId))
+  )
+)
+
+;; check if contract caller is city wallet
+(define-private (is-authorized-city)
+  (is-eq contract-caller (var-get cityWallet))
+)
+
+;; TOKEN MANAGEMENT
+
+(define-public (set-token-uri (targetContract <tokenTrait>) (newUri (optional (string-utf8 256))))
+  (begin
+    (asserts! (is-authorized-city) ERR_UNAUTHORIZED)
+    (as-contract (try! (contract-call? targetContract set-token-uri newUri)))
+    (ok true)
+  )
+)
+
+;; APPROVERS MANAGEMENT
+
+(define-public (execute-replace-approver-job (jobId uint))
+  (let
+    (
+      (oldApprover (unwrap! (get-principal-value-by-name jobId "oldApprover") ERR_UNKNOWN_ARGUMENT))
+      (newApprover (unwrap! (get-principal-value-by-name jobId "newApprover") ERR_UNKNOWN_ARGUMENT))
+    )
+    (asserts! (is-approver contract-caller) ERR_UNAUTHORIZED)
+    (map-set Approvers oldApprover false)
+    (map-set Approvers newApprover true)
+    (as-contract (mark-job-as-executed jobId))
+  )
+)
+
+;; CONTRACT INITIALIZATION
+
+(map-insert Approvers 'ST1J4G6RR643BCG8G8SR6M2D9Z9KXT2NJDRK3FBTK true)
+(map-insert Approvers 'ST20ATRN26N9P05V2F1RHFRV24X8C8M3W54E427B2 true)
+(map-insert Approvers 'ST21HMSJATHZ888PD0S0SSTWP4J61TCRJYEVQ0STB true)
+(map-insert Approvers 'ST2QXSK64YQX3CQPC530K79XWQ98XFAM9W3XKEH3N true)
+(map-insert Approvers 'ST3DG3R65C9TTEEW5BC5XTSY0M1JM7NBE7GVWKTVJ true)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; TESTING FUNCTIONS
+;; DELETE BEFORE DEPLOYING TO MAINNET
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-constant DEPLOYED_AT block-height)
+
+(define-private (is-test-env)
+  (is-eq DEPLOYED_AT u0)
+)
+
+(define-public (test-initialize-contracts (coreContract <coreTrait>))
+  (let
+    (
+      (coreContractAddress (contract-of coreContract))
+    )
+    (asserts! (is-test-env) ERR_UNAUTHORIZED)
+    (asserts! (not (var-get initialized)) ERR_UNAUTHORIZED)
+    (map-set CoreContracts
+      coreContractAddress
+      {
+        state: STATE_DEPLOYED,
+        startHeight: u0,
+        endHeight: u0
+      })
+    (try! (contract-call? coreContract set-city-wallet (var-get cityWallet)))
+    (var-set initialized true)
+    (ok true)
+  )
+)
+
+(define-public (test-set-active-core-contract)
+  (begin
+    (asserts! (is-test-env) ERR_UNAUTHORIZED)
+    (ok (var-set activeCoreContract .miamicoin-core-v1))
+  )
+)
+
+(define-public (test-set-core-contract-state (coreContract <coreTrait>) (state uint))
+  (let
+    (
+      (coreContractAddress (contract-of coreContract))
+    )
+    (asserts! (is-test-env) ERR_UNAUTHORIZED)
+    (asserts! (or (>= state STATE_DEPLOYED) (<= state STATE_INACTIVE)) ERR_UNAUTHORIZED)
+    (map-set CoreContracts
+      coreContractAddress
+      {
+        state: state,
+        startHeight: u0,
+        endHeight: u0
+      }
+    )
+    (ok true)
+  )
+)

--- a/contracts/cities/mia/local/miamicoin-core-v1.clar
+++ b/contracts/cities/mia/local/miamicoin-core-v1.clar
@@ -1,0 +1,945 @@
+;; CITYCOINS CORE CONTRACT
+
+;; GENERAL CONFIGURATION
+
+(impl-trait .citycoin-core-trait.citycoin-core)
+(define-constant CONTRACT_OWNER tx-sender)
+
+;; ERROR CODES
+
+(define-constant ERR_UNAUTHORIZED (err u1000))
+(define-constant ERR_USER_ALREADY_REGISTERED (err u1001))
+(define-constant ERR_USER_NOT_FOUND (err u1002))
+(define-constant ERR_USER_ID_NOT_FOUND (err u1003))
+(define-constant ERR_ACTIVATION_THRESHOLD_REACHED (err u1004))
+(define-constant ERR_CONTRACT_NOT_ACTIVATED (err u1005))
+(define-constant ERR_USER_ALREADY_MINED (err u1006))
+(define-constant ERR_INSUFFICIENT_COMMITMENT (err u1007))
+(define-constant ERR_INSUFFICIENT_BALANCE (err u1008))
+(define-constant ERR_USER_DID_NOT_MINE_IN_BLOCK (err u1009))
+(define-constant ERR_CLAIMED_BEFORE_MATURITY (err u1010))
+(define-constant ERR_NO_MINERS_AT_BLOCK (err u1011))
+(define-constant ERR_REWARD_ALREADY_CLAIMED (err u1012))
+(define-constant ERR_MINER_DID_NOT_WIN (err u1013))
+(define-constant ERR_NO_VRF_SEED_FOUND (err u1014))
+(define-constant ERR_STACKING_NOT_AVAILABLE (err u1015))
+(define-constant ERR_CANNOT_STACK (err u1016))
+(define-constant ERR_REWARD_CYCLE_NOT_COMPLETED (err u1017))
+(define-constant ERR_NOTHING_TO_REDEEM (err u1018))
+(define-constant ERR_UNABLE_TO_FIND_CITY_WALLET (err u1019))
+(define-constant ERR_CLAIM_IN_WRONG_CONTRACT (err u1020))
+(define-constant ERR_BLOCK_HEIGHT_IN_PAST (err u1021))
+
+;; CITY WALLET MANAGEMENT
+
+;; initial value for city wallet, set to this contract until initialized
+(define-data-var cityWallet principal .miamicoin-core-v1)
+
+;; returns set city wallet principal
+(define-read-only (get-city-wallet)
+  (var-get cityWallet)
+)
+ 
+;; protected function to update city wallet variable
+(define-public (set-city-wallet (newCityWallet principal))
+  (begin
+    (asserts! (is-authorized-auth) ERR_UNAUTHORIZED)
+    (ok (var-set cityWallet newCityWallet))
+  )
+)
+
+;; REGISTRATION
+
+(define-data-var activationBlock uint u340282366920938463463374607431768211455)
+(define-data-var activationDelay uint u150)
+(define-data-var activationReached bool false)
+(define-data-var activationThreshold uint u20)
+(define-data-var usersNonce uint u0)
+
+;; returns Stacks block height registration was activated at plus activationDelay
+(define-read-only (get-activation-block)
+  (let
+    (
+      (activated (var-get activationReached))
+    )
+    (asserts! activated ERR_CONTRACT_NOT_ACTIVATED)
+    (ok (var-get activationBlock))
+  )
+)
+
+;; returns activation delay
+(define-read-only (get-activation-delay)
+  (var-get activationDelay)
+)
+
+;; returns activation status as boolean
+(define-read-only (get-activation-status)
+  (var-get activationReached)
+)
+
+;; returns activation threshold
+(define-read-only (get-activation-threshold)
+  (var-get activationThreshold)
+)
+
+;; returns number of registered users, used for activation and tracking user IDs
+(define-read-only (get-registered-users-nonce)
+  (var-get usersNonce)
+)
+
+;; store user principal by user id
+(define-map Users
+  uint
+  principal
+)
+
+;; store user id by user principal
+(define-map UserIds
+  principal
+  uint
+)
+
+;; returns (some userId) or none
+(define-read-only (get-user-id (user principal))
+  (map-get? UserIds user)
+)
+
+;; returns (some userPrincipal) or none
+(define-read-only (get-user (userId uint))
+  (map-get? Users userId)
+)
+
+;; returns user ID if it has been created, or creates and returns new ID
+(define-private (get-or-create-user-id (user principal))
+  (match
+    (map-get? UserIds user)
+    value value
+    (let
+      (
+        (newId (+ u1 (var-get usersNonce)))
+      )
+      (map-set Users newId user)
+      (map-set UserIds user newId)
+      (var-set usersNonce newId)
+      newId
+    )
+  )
+)
+
+;; registers users that signal activation of contract until threshold is met
+(define-public (register-user (memo (optional (string-utf8 50))))
+  (let
+    (
+      (newId (+ u1 (var-get usersNonce)))
+      (threshold (var-get activationThreshold))
+      (initialized (contract-call? .miamicoin-auth is-initialized))
+    )
+
+    (asserts! initialized ERR_UNAUTHORIZED)
+
+    (asserts! (is-none (map-get? UserIds tx-sender))
+      ERR_USER_ALREADY_REGISTERED)
+
+    (asserts! (<= newId threshold)
+      ERR_ACTIVATION_THRESHOLD_REACHED)
+
+    (if (is-some memo)
+      (print memo)
+      none
+    )
+
+    (get-or-create-user-id tx-sender)
+
+    (if (is-eq newId threshold)
+      (let
+        (
+          (activationBlockVal (+ block-height (var-get activationDelay)))
+        )
+        (try! (contract-call? .miamicoin-auth activate-core-contract (as-contract tx-sender) activationBlockVal))
+        (try! (contract-call? .miamicoin-token activate-token (as-contract tx-sender) activationBlockVal))
+        (try! (set-coinbase-thresholds))
+        (var-set activationReached true)
+        (var-set activationBlock activationBlockVal)
+        (ok true)
+      )
+      (ok true)
+    )
+  )
+)
+
+;; MINING CONFIGURATION
+
+;; define split to custodied wallet address for the city
+(define-constant SPLIT_CITY_PCT u30)
+
+;; how long a miner must wait before block winner can claim their minted tokens
+(define-data-var tokenRewardMaturity uint u100)
+
+;; At a given Stacks block height:
+;; - how many miners were there
+;; - what was the total amount submitted
+;; - what was the total amount submitted to the city
+;; - what was the total amount submitted to Stackers
+;; - was the block reward claimed
+(define-map MiningStatsAtBlock
+  uint
+  {
+    minersCount: uint,
+    amount: uint,
+    amountToCity: uint,
+    amountToStackers: uint,
+    rewardClaimed: bool
+  }
+)
+
+;; returns map MiningStatsAtBlock at a given Stacks block height if it exists
+(define-read-only (get-mining-stats-at-block (stacksHeight uint))
+  (map-get? MiningStatsAtBlock stacksHeight)
+)
+
+;; returns map MiningStatsAtBlock at a given Stacks block height
+;; or, an empty structure
+(define-read-only (get-mining-stats-at-block-or-default (stacksHeight uint))
+  (default-to {
+      minersCount: u0,
+      amount: u0,
+      amountToCity: u0,
+      amountToStackers: u0,
+      rewardClaimed: false
+    }
+    (map-get? MiningStatsAtBlock stacksHeight)
+  )
+)
+
+;; At a given Stacks block height and user ID:
+;; - what is their ustx commitment
+;; - what are the low/high values (used for VRF)
+(define-map MinersAtBlock
+  {
+    stacksHeight: uint,
+    userId: uint
+  }
+  {
+    ustx: uint,
+    lowValue: uint,
+    highValue: uint,
+    winner: bool
+  }
+)
+
+;; returns true if a given miner has already mined at a given block height
+(define-read-only (has-mined-at-block (stacksHeight uint) (userId uint))
+  (is-some 
+    (map-get? MinersAtBlock { stacksHeight: stacksHeight, userId: userId })
+  )
+)
+
+;; returns map MinersAtBlock at a given Stacks block height for a user ID
+(define-read-only (get-miner-at-block (stacksHeight uint) (userId uint))
+  (map-get? MinersAtBlock { stacksHeight: stacksHeight, userId: userId })
+)
+
+;; returns map MinersAtBlock at a given Stacks block height for a user ID
+;; or, an empty structure
+(define-read-only (get-miner-at-block-or-default (stacksHeight uint) (userId uint))
+  (default-to {
+    highValue: u0,
+    lowValue: u0,
+    ustx: u0,
+    winner: false
+  }
+    (map-get? MinersAtBlock { stacksHeight: stacksHeight, userId: userId }))
+)
+
+;; At a given Stacks block height:
+;; - what is the max highValue from MinersAtBlock (used for VRF)
+(define-map MinersAtBlockHighValue
+  uint
+  uint
+)
+
+;; returns last high value from map MinersAtBlockHighValue
+(define-read-only (get-last-high-value-at-block (stacksHeight uint))
+  (default-to u0
+    (map-get? MinersAtBlockHighValue stacksHeight))
+)
+
+;; At a given Stacks block height:
+;; - what is the userId of miner who won this block
+(define-map BlockWinnerIds
+  uint
+  uint
+)
+
+(define-read-only (get-block-winner-id (stacksHeight uint))
+  (map-get? BlockWinnerIds stacksHeight)
+)
+
+;; MINING ACTIONS
+
+(define-public (mine-tokens (amountUstx uint) (memo (optional (buff 34))))
+  (let
+    (
+      (userId (get-or-create-user-id tx-sender))
+    )
+    (try! (mine-tokens-at-block userId block-height amountUstx memo))
+    (ok true)
+  )
+)
+
+(define-public (mine-many (amounts (list 200 uint)))
+  (begin
+    (asserts! (get-activation-status) ERR_CONTRACT_NOT_ACTIVATED)
+    (asserts! (> (len amounts) u0) ERR_INSUFFICIENT_COMMITMENT)
+    (match (fold mine-single amounts (ok { userId: (get-or-create-user-id tx-sender), toStackers: u0, toCity: u0, stacksHeight: block-height }))
+      okReturn 
+      (begin
+        (asserts! (>= (stx-get-balance tx-sender) (+ (get toStackers okReturn) (get toCity okReturn))) ERR_INSUFFICIENT_BALANCE)
+        (if (> (get toStackers okReturn ) u0)
+          (try! (stx-transfer? (get toStackers okReturn ) tx-sender (as-contract tx-sender)))
+          false
+        )
+        (try! (stx-transfer? (get toCity okReturn) tx-sender (var-get cityWallet)))
+        (print { 
+          firstBlock: block-height, 
+          lastBlock: (- (+ block-height (len amounts)) u1) 
+        })
+        (ok true)
+      )
+      errReturn (err errReturn)
+    )
+  )
+)
+
+(define-private (mine-single 
+  (amountUstx uint) 
+  (return (response 
+    { 
+      userId: uint,
+      toStackers: uint,
+      toCity: uint,
+      stacksHeight: uint
+    }
+    uint
+  )))
+
+  (match return okReturn
+    (let
+      (
+        (stacksHeight (get stacksHeight okReturn))
+        (rewardCycle (default-to u0 (get-reward-cycle stacksHeight)))
+        (stackingActive (stacking-active-at-cycle rewardCycle))
+        (toCity
+          (if stackingActive
+            (/ (* SPLIT_CITY_PCT amountUstx) u100)
+            amountUstx
+          )
+        )
+        (toStackers (- amountUstx toCity))
+      )
+      (asserts! (not (has-mined-at-block stacksHeight (get userId okReturn))) ERR_USER_ALREADY_MINED)
+      (asserts! (> amountUstx u0) ERR_INSUFFICIENT_COMMITMENT)
+      (try! (set-tokens-mined (get userId okReturn) stacksHeight amountUstx toStackers toCity))
+      (ok (merge okReturn 
+        {
+          toStackers: (+ (get toStackers okReturn) toStackers),
+          toCity: (+ (get toCity okReturn) toCity),
+          stacksHeight: (+ stacksHeight u1)
+        }
+      ))
+    )
+    errReturn (err errReturn)
+  ) 
+)
+
+(define-private (mine-tokens-at-block (userId uint) (stacksHeight uint) (amountUstx uint) (memo (optional (buff 34))))
+  (let
+    (
+      (rewardCycle (default-to u0 (get-reward-cycle stacksHeight)))
+      (stackingActive (stacking-active-at-cycle rewardCycle))
+      (toCity
+        (if stackingActive
+          (/ (* SPLIT_CITY_PCT amountUstx) u100)
+          amountUstx
+        )
+      )
+      (toStackers (- amountUstx toCity))
+    )
+    (asserts! (get-activation-status) ERR_CONTRACT_NOT_ACTIVATED)
+    (asserts! (not (has-mined-at-block stacksHeight userId)) ERR_USER_ALREADY_MINED)
+    (asserts! (> amountUstx u0) ERR_INSUFFICIENT_COMMITMENT)
+    (asserts! (>= (stx-get-balance tx-sender) amountUstx) ERR_INSUFFICIENT_BALANCE)
+    (try! (set-tokens-mined userId stacksHeight amountUstx toStackers toCity))
+    (if (is-some memo)
+      (print memo)
+      none
+    )
+    (if stackingActive
+      (try! (stx-transfer? toStackers tx-sender (as-contract tx-sender)))
+      false
+    )
+    (try! (stx-transfer? toCity tx-sender (var-get cityWallet)))
+    (ok true)
+  )
+)
+
+(define-private (set-tokens-mined (userId uint) (stacksHeight uint) (amountUstx uint) (toStackers uint) (toCity uint))
+  (let
+    (
+      (blockStats (get-mining-stats-at-block-or-default stacksHeight))
+      (newMinersCount (+ (get minersCount blockStats) u1))
+      (minerLowVal (get-last-high-value-at-block stacksHeight))
+      (rewardCycle (unwrap! (get-reward-cycle stacksHeight)
+        ERR_STACKING_NOT_AVAILABLE))
+      (rewardCycleStats (get-stacking-stats-at-cycle-or-default rewardCycle))
+    )
+    (map-set MiningStatsAtBlock
+      stacksHeight
+      {
+        minersCount: newMinersCount,
+        amount: (+ (get amount blockStats) amountUstx),
+        amountToCity: (+ (get amountToCity blockStats) toCity),
+        amountToStackers: (+ (get amountToStackers blockStats) toStackers),
+        rewardClaimed: false
+      }
+    )
+    (map-set MinersAtBlock
+      {
+        stacksHeight: stacksHeight,
+        userId: userId
+      }
+      {
+        ustx: amountUstx,
+        lowValue: (if (> minerLowVal u0) (+ minerLowVal u1) u0),
+        highValue: (+ minerLowVal amountUstx),
+        winner: false
+      }
+    )
+    (map-set MinersAtBlockHighValue
+      stacksHeight
+      (+ minerLowVal amountUstx)
+    )
+    (if (> toStackers u0)
+      (map-set StackingStatsAtCycle
+        rewardCycle
+        {
+          amountUstx: (+ (get amountUstx rewardCycleStats) toStackers),
+          amountToken: (get amountToken rewardCycleStats)
+        }
+      )
+      false
+    )
+    (ok true)
+  )
+)
+
+;; MINING REWARD CLAIM ACTIONS
+
+;; calls function to claim mining reward in active logic contract
+(define-public (claim-mining-reward (minerBlockHeight uint))
+  (begin
+    (asserts! (or (is-eq (var-get shutdownHeight) u0) (< minerBlockHeight (var-get shutdownHeight))) ERR_CLAIM_IN_WRONG_CONTRACT)
+    (try! (claim-mining-reward-at-block tx-sender block-height minerBlockHeight))
+    (ok true)
+  )
+)
+
+;; Determine whether or not the given principal can claim the mined tokens at a particular block height,
+;; given the miners record for that block height, a random sample, and the current block height.
+(define-private (claim-mining-reward-at-block (user principal) (stacksHeight uint) (minerBlockHeight uint))
+  (let
+    (
+      (maturityHeight (+ (var-get tokenRewardMaturity) minerBlockHeight))
+      (userId (unwrap! (get-user-id user) ERR_USER_ID_NOT_FOUND))
+      (blockStats (unwrap! (get-mining-stats-at-block minerBlockHeight) ERR_NO_MINERS_AT_BLOCK))
+      (minerStats (unwrap! (get-miner-at-block minerBlockHeight userId) ERR_USER_DID_NOT_MINE_IN_BLOCK))
+      (isMature (asserts! (> stacksHeight maturityHeight) ERR_CLAIMED_BEFORE_MATURITY))
+      (vrfSample (unwrap! (contract-call? .citycoin-vrf get-random-uint-at-block maturityHeight) ERR_NO_VRF_SEED_FOUND))
+      (commitTotal (get-last-high-value-at-block minerBlockHeight))
+      (winningValue (mod vrfSample commitTotal))
+    )
+    (asserts! (not (get rewardClaimed blockStats)) ERR_REWARD_ALREADY_CLAIMED)
+    (asserts! (and (>= winningValue (get lowValue minerStats)) (<= winningValue (get highValue minerStats)))
+      ERR_MINER_DID_NOT_WIN)
+    (try! (set-mining-reward-claimed userId minerBlockHeight))
+    (ok true)
+  )
+)
+
+(define-private (set-mining-reward-claimed (userId uint) (minerBlockHeight uint))
+  (let
+    (
+      (blockStats (get-mining-stats-at-block-or-default minerBlockHeight))
+      (minerStats (get-miner-at-block-or-default minerBlockHeight userId))
+      (user (unwrap! (get-user userId) ERR_USER_NOT_FOUND))
+    )
+    (map-set MiningStatsAtBlock
+      minerBlockHeight
+      {
+        minersCount: (get minersCount blockStats),
+        amount: (get amount blockStats),
+        amountToCity: (get amountToCity blockStats),
+        amountToStackers: (get amountToStackers blockStats),
+        rewardClaimed: true
+      }
+    )
+    (map-set MinersAtBlock
+      {
+        stacksHeight: minerBlockHeight,
+        userId: userId
+      }
+      {
+        ustx: (get ustx minerStats),
+        lowValue: (get lowValue minerStats),
+        highValue: (get highValue minerStats),
+        winner: true
+      }
+    )
+    (map-set BlockWinnerIds
+      minerBlockHeight
+      userId
+    )
+    (try! (mint-coinbase user minerBlockHeight))
+    (ok true)
+  )
+)
+
+(define-read-only (is-block-winner (user principal) (minerBlockHeight uint))
+  (is-block-winner-and-can-claim user minerBlockHeight false)
+)
+
+(define-read-only (can-claim-mining-reward (user principal) (minerBlockHeight uint))
+  (is-block-winner-and-can-claim user minerBlockHeight true)
+)
+
+(define-private (is-block-winner-and-can-claim (user principal) (minerBlockHeight uint) (testCanClaim bool))
+  (let
+    (
+      (userId (unwrap! (get-user-id user) false))
+      (blockStats (unwrap! (get-mining-stats-at-block minerBlockHeight) false))
+      (minerStats (unwrap! (get-miner-at-block minerBlockHeight userId) false))
+      (maturityHeight (+ (var-get tokenRewardMaturity) minerBlockHeight))
+      (vrfSample (unwrap! (contract-call? .citycoin-vrf get-random-uint-at-block maturityHeight) false))
+      (commitTotal (get-last-high-value-at-block minerBlockHeight))
+      (winningValue (mod vrfSample commitTotal))
+    )
+    (if (and (>= winningValue (get lowValue minerStats)) (<= winningValue (get highValue minerStats)))
+      (if testCanClaim (not (get rewardClaimed blockStats)) true)
+      false
+    )
+  )
+)
+
+;; STACKING CONFIGURATION
+
+(define-constant MAX_REWARD_CYCLES u32)
+(define-constant REWARD_CYCLE_INDEXES (list u0 u1 u2 u3 u4 u5 u6 u7 u8 u9 u10 u11 u12 u13 u14 u15 u16 u17 u18 u19 u20 u21 u22 u23 u24 u25 u26 u27 u28 u29 u30 u31))
+
+;; how long a reward cycle is
+(define-data-var rewardCycleLength uint u2100)
+
+;; At a given reward cycle:
+;; - how many Stackers were there
+;; - what is the total uSTX submitted by miners
+;; - what is the total amount of tokens stacked
+(define-map StackingStatsAtCycle
+  uint
+  {
+    amountUstx: uint,
+    amountToken: uint
+  }
+)
+
+;; returns the total stacked tokens and committed uSTX for a given reward cycle
+(define-read-only (get-stacking-stats-at-cycle (rewardCycle uint))
+  (map-get? StackingStatsAtCycle rewardCycle)
+)
+
+;; returns the total stacked tokens and committed uSTX for a given reward cycle
+;; or, an empty structure
+(define-read-only (get-stacking-stats-at-cycle-or-default (rewardCycle uint))
+  (default-to { amountUstx: u0, amountToken: u0 }
+    (map-get? StackingStatsAtCycle rewardCycle))
+)
+
+;; At a given reward cycle and user ID:
+;; - what is the total tokens Stacked?
+;; - how many tokens should be returned? (based on Stacking period)
+(define-map StackerAtCycle
+  {
+    rewardCycle: uint,
+    userId: uint
+  }
+  {
+    amountStacked: uint,
+    toReturn: uint
+  }
+)
+
+(define-read-only (get-stacker-at-cycle (rewardCycle uint) (userId uint))
+  (map-get? StackerAtCycle { rewardCycle: rewardCycle, userId: userId })
+)
+
+(define-read-only (get-stacker-at-cycle-or-default (rewardCycle uint) (userId uint))
+  (default-to { amountStacked: u0, toReturn: u0 }
+    (map-get? StackerAtCycle { rewardCycle: rewardCycle, userId: userId }))
+)
+
+;; get the reward cycle for a given Stacks block height
+(define-read-only (get-reward-cycle (stacksHeight uint))
+  (let
+    (
+      (firstStackingBlock (var-get activationBlock))
+      (rcLen (var-get rewardCycleLength))
+    )
+    (if (>= stacksHeight firstStackingBlock)
+      (some (/ (- stacksHeight firstStackingBlock) rcLen))
+      none)
+  )
+)
+
+;; determine if stacking is active in a given cycle
+(define-read-only (stacking-active-at-cycle (rewardCycle uint))
+  (is-some
+    (get amountToken (map-get? StackingStatsAtCycle rewardCycle))
+  )
+)
+
+;; get the first Stacks block height for a given reward cycle.
+(define-read-only (get-first-stacks-block-in-reward-cycle (rewardCycle uint))
+  (+ (var-get activationBlock) (* (var-get rewardCycleLength) rewardCycle))
+)
+
+;; getter for get-entitled-stacking-reward that specifies block height
+(define-read-only (get-stacking-reward (userId uint) (targetCycle uint))
+  (get-entitled-stacking-reward userId targetCycle block-height)
+)
+
+;; get uSTX a Stacker can claim, given reward cycle they stacked in and current block height
+;; this method only returns a positive value if:
+;; - the current block height is in a subsequent reward cycle
+;; - the stacker actually locked up tokens in the target reward cycle
+;; - the stacker locked up _enough_ tokens to get at least one uSTX
+;; it is possible to Stack tokens and not receive uSTX:
+;; - if no miners commit during this reward cycle
+;; - the amount stacked by user is too few that you'd be entitled to less than 1 uSTX
+(define-private (get-entitled-stacking-reward (userId uint) (targetCycle uint) (stacksHeight uint))
+  (let
+    (
+      (rewardCycleStats (get-stacking-stats-at-cycle-or-default targetCycle))
+      (stackerAtCycle (get-stacker-at-cycle-or-default targetCycle userId))
+      (totalUstxThisCycle (get amountUstx rewardCycleStats))
+      (totalStackedThisCycle (get amountToken rewardCycleStats))
+      (userStackedThisCycle (get amountStacked stackerAtCycle))
+    )
+    (match (get-reward-cycle stacksHeight)
+      currentCycle
+      (if (or (<= currentCycle targetCycle) (is-eq u0 userStackedThisCycle))
+        ;; this cycle hasn't finished, or Stacker contributed nothing
+        u0
+        ;; (totalUstxThisCycle * userStackedThisCycle) / totalStackedThisCycle
+        (/ (* totalUstxThisCycle userStackedThisCycle) totalStackedThisCycle)
+      )
+      ;; before first reward cycle
+      u0
+    )
+  )
+)
+
+;; STACKING ACTIONS
+
+(define-public (stack-tokens (amountTokens uint) (lockPeriod uint))
+  (let
+    (
+      (userId (get-or-create-user-id tx-sender))
+    )
+    (try! (stack-tokens-at-cycle tx-sender userId amountTokens block-height lockPeriod))
+    (ok true)
+  )
+)
+
+(define-private (stack-tokens-at-cycle (user principal) (userId uint) (amountTokens uint) (startHeight uint) (lockPeriod uint))
+  (let
+    (
+      (currentCycle (unwrap! (get-reward-cycle startHeight) ERR_STACKING_NOT_AVAILABLE))
+      (targetCycle (+ u1 currentCycle))
+      (commitment {
+        stackerId: userId,
+        amount: amountTokens,
+        first: targetCycle,
+        last: (+ targetCycle lockPeriod)
+      })
+    )
+    (asserts! (get-activation-status) ERR_CONTRACT_NOT_ACTIVATED)
+    (asserts! (and (> lockPeriod u0) (<= lockPeriod MAX_REWARD_CYCLES))
+      ERR_CANNOT_STACK)
+    (asserts! (> amountTokens u0) ERR_CANNOT_STACK)
+    (try! (contract-call? .miamicoin-token transfer amountTokens tx-sender (as-contract tx-sender) none))
+    (print {
+      firstCycle: targetCycle, 
+      lastCycle: (- (+ targetCycle lockPeriod) u1)
+    })
+    (match (fold stack-tokens-closure REWARD_CYCLE_INDEXES (ok commitment))
+      okValue (ok true)
+      errValue (err errValue)
+    )
+  )
+)
+
+(define-private (stack-tokens-closure (rewardCycleIdx uint)
+  (commitmentResponse (response 
+    {
+      stackerId: uint,
+      amount: uint,
+      first: uint,
+      last: uint
+    }
+    uint
+  )))
+
+  (match commitmentResponse
+    commitment 
+    (let
+      (
+        (stackerId (get stackerId commitment))
+        (amountToken (get amount commitment))
+        (firstCycle (get first commitment))
+        (lastCycle (get last commitment))
+        (targetCycle (+ firstCycle rewardCycleIdx))
+      )
+      (begin
+        (if (and (>= targetCycle firstCycle) (< targetCycle lastCycle))
+          (begin
+            (if (is-eq targetCycle (- lastCycle u1))
+              (set-tokens-stacked stackerId targetCycle amountToken amountToken)
+              (set-tokens-stacked stackerId targetCycle amountToken u0)
+            )
+            true
+          )
+          false
+        )
+        commitmentResponse
+      )
+    )
+    errValue commitmentResponse
+  )
+)
+
+(define-private (set-tokens-stacked (userId uint) (targetCycle uint) (amountStacked uint) (toReturn uint))
+  (let
+    (
+      (rewardCycleStats (get-stacking-stats-at-cycle-or-default targetCycle))
+      (stackerAtCycle (get-stacker-at-cycle-or-default targetCycle userId))
+    )
+    (map-set StackingStatsAtCycle
+      targetCycle
+      {
+        amountUstx: (get amountUstx rewardCycleStats),
+        amountToken: (+ amountStacked (get amountToken rewardCycleStats))
+      }
+    )
+    (map-set StackerAtCycle
+      {
+        rewardCycle: targetCycle,
+        userId: userId
+      }
+      {
+        amountStacked: (+ amountStacked (get amountStacked stackerAtCycle)),
+        toReturn: (+ toReturn (get toReturn stackerAtCycle))
+      }
+    )
+  )
+)
+
+;; STACKING REWARD CLAIMS
+
+;; calls function to claim stacking reward in active logic contract
+(define-public (claim-stacking-reward (targetCycle uint))
+  (begin
+    (try! (claim-stacking-reward-at-cycle tx-sender block-height targetCycle))
+    (ok true)
+  )
+)
+
+(define-private (claim-stacking-reward-at-cycle (user principal) (stacksHeight uint) (targetCycle uint))
+  (let
+    (
+      (currentCycle (unwrap! (get-reward-cycle stacksHeight) ERR_STACKING_NOT_AVAILABLE))
+      (userId (unwrap! (get-user-id user) ERR_USER_ID_NOT_FOUND))
+      (entitledUstx (get-entitled-stacking-reward userId targetCycle stacksHeight))
+      (stackerAtCycle (get-stacker-at-cycle-or-default targetCycle userId))
+      (toReturn (get toReturn stackerAtCycle))
+    )
+    (asserts! (or
+      (is-eq true (var-get isShutdown))
+      (> currentCycle targetCycle))
+      ERR_REWARD_CYCLE_NOT_COMPLETED)
+    (asserts! (or (> toReturn u0) (> entitledUstx u0)) ERR_NOTHING_TO_REDEEM)
+    ;; disable ability to claim again
+    (map-set StackerAtCycle
+      {
+        rewardCycle: targetCycle,
+        userId: userId
+      }
+      {
+        amountStacked: u0,
+        toReturn: u0
+      }
+    )
+    ;; send back tokens if user was eligible
+    (if (> toReturn u0)
+      (try! (as-contract (contract-call? .miamicoin-token transfer toReturn tx-sender user none)))
+      true
+    )
+    ;; send back rewards if user was eligible
+    (if (> entitledUstx u0)
+      (try! (as-contract (stx-transfer? entitledUstx tx-sender user)))
+      true
+    )
+    (ok true)
+  )
+)
+
+;; TOKEN CONFIGURATION
+
+;; store block height at each halving, set by register-user in core contract
+(define-data-var coinbaseThreshold1 uint u0)
+(define-data-var coinbaseThreshold2 uint u0)
+(define-data-var coinbaseThreshold3 uint u0)
+(define-data-var coinbaseThreshold4 uint u0)
+(define-data-var coinbaseThreshold5 uint u0)
+
+(define-private (set-coinbase-thresholds)
+  (let
+    (
+      (coinbaseAmounts (try! (contract-call? .miamicoin-token get-coinbase-thresholds)))
+    )
+    (var-set coinbaseThreshold1 (get coinbaseThreshold1 coinbaseAmounts))
+    (var-set coinbaseThreshold2 (get coinbaseThreshold2 coinbaseAmounts))
+    (var-set coinbaseThreshold3 (get coinbaseThreshold3 coinbaseAmounts))
+    (var-set coinbaseThreshold4 (get coinbaseThreshold4 coinbaseAmounts))
+    (var-set coinbaseThreshold5 (get coinbaseThreshold5 coinbaseAmounts))
+    (ok true)
+  )
+)
+
+;; return coinbase thresholds if contract activated
+(define-read-only (get-coinbase-thresholds)
+  (let
+    (
+      (activated (var-get activationReached))
+    )
+    (asserts! activated ERR_CONTRACT_NOT_ACTIVATED)
+    (ok {
+      coinbaseThreshold1: (var-get coinbaseThreshold1),
+      coinbaseThreshold2: (var-get coinbaseThreshold2),
+      coinbaseThreshold3: (var-get coinbaseThreshold3),
+      coinbaseThreshold4: (var-get coinbaseThreshold4),
+      coinbaseThreshold5: (var-get coinbaseThreshold5)
+    })
+  )
+)
+
+;; function for deciding how many tokens to mint, depending on when they were mined
+(define-read-only (get-coinbase-amount (minerBlockHeight uint))
+  (begin
+    ;; if contract is not active, return 0
+    (asserts! (>= minerBlockHeight (var-get activationBlock)) u0)
+    ;; if contract is active, return based on issuance schedule
+    ;; halvings occur every 210,000 blocks for 1,050,000 Stacks blocks
+    ;; then mining continues indefinitely with 3,125 tokens as the reward
+    (asserts! (> minerBlockHeight (var-get coinbaseThreshold1))
+      (if (<= (- minerBlockHeight (var-get activationBlock)) u10000)
+        ;; bonus reward first 10,000 blocks
+        u250000
+        ;; standard reward remaining 200,000 blocks until 1st halving
+        u100000
+      )
+    )
+    ;; computations based on each halving threshold
+    (asserts! (> minerBlockHeight (var-get coinbaseThreshold2)) u50000)
+    (asserts! (> minerBlockHeight (var-get coinbaseThreshold3)) u25000)
+    (asserts! (> minerBlockHeight (var-get coinbaseThreshold4)) u12500)
+    (asserts! (> minerBlockHeight (var-get coinbaseThreshold5)) u6250)
+    ;; default value after 5th halving
+    u3125
+  )
+)
+
+;; mint new tokens for claimant who won at given Stacks block height
+(define-private (mint-coinbase (recipient principal) (stacksHeight uint))
+  (as-contract (contract-call? .miamicoin-token mint (get-coinbase-amount stacksHeight) recipient))
+)
+
+;; UTILITIES
+
+(define-data-var shutdownHeight uint u0)
+(define-data-var isShutdown bool false)
+
+;; stop mining and stacking operations
+;; in preparation for a core upgrade
+(define-public (shutdown-contract (stacksHeight uint))
+  (begin
+    ;; make sure block height is in the future
+    (asserts! (>= stacksHeight block-height) ERR_BLOCK_HEIGHT_IN_PAST)
+    ;; only allow shutdown request from AUTH
+    (asserts! (is-authorized-auth) ERR_UNAUTHORIZED)
+    ;; set variables to disable mining/stacking in CORE
+    (var-set activationReached false)
+    (var-set shutdownHeight stacksHeight)
+    ;; set variable to allow for all stacking claims
+    (var-set isShutdown true)
+    (ok true)
+  )
+)
+
+;; check if contract caller is city wallet
+(define-private (is-authorized-city)
+  (is-eq contract-caller (var-get cityWallet))
+)
+
+;; check if contract caller is contract owner
+(define-private (is-authorized-owner)
+  (is-eq contract-caller CONTRACT_OWNER)
+)
+
+;; checks if caller is Auth contract
+(define-private (is-authorized-auth)
+  (is-eq contract-caller .miamicoin-auth)
+)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; TESTING FUNCTIONS
+;; DELETE BEFORE DEPLOYING TO MAINNET
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-constant DEPLOYED_AT block-height)
+
+(define-private (is-test-env)
+  (is-eq DEPLOYED_AT u0)
+)
+
+(use-trait coreTrait .citycoin-core-trait.citycoin-core)
+
+(define-public (test-set-city-wallet (newCityWallet principal))
+  (begin
+    (asserts! (is-test-env) ERR_UNAUTHORIZED)
+    (ok (var-set cityWallet newCityWallet))
+  )
+)
+
+(define-public (test-set-activation-threshold (newThreshold uint))
+  (begin
+    (asserts! (is-test-env) ERR_UNAUTHORIZED)
+    (ok (var-set activationThreshold newThreshold))
+  )
+)
+
+(define-public (test-initialize-core (coreContract <coreTrait>))
+  (begin
+    (asserts! (is-test-env) ERR_UNAUTHORIZED)
+    (var-set activationThreshold u1)
+    (try! (contract-call? .miamicoin-auth test-initialize-contracts coreContract))
+    (ok true)
+  )
+)

--- a/contracts/cities/mia/local/miamicoin-token.clar
+++ b/contracts/cities/mia/local/miamicoin-token.clar
@@ -1,4 +1,4 @@
-;; CITYCOINS TOKEN CONTRACT
+;; MIAMICOIN TOKEN CONTRACT
 
 ;; CONTRACT OWNER
 
@@ -21,7 +21,7 @@
 ;; testnet: (impl-trait 'STR8P3RD1EHA8AA37ERSSSZSWKS9T2GYQFGXNA4C.sip-010-trait-ft-standard.sip-010-trait)
 ;; mainnet: (impl-trait 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.sip-010-trait)
 
-(define-fungible-token citycoins)
+(define-fungible-token miamicoin)
 
 ;; SIP-010 FUNCTIONS
 
@@ -32,16 +32,16 @@
       (print memo)
       none
     )
-    (ft-transfer? citycoins amount from to)
+    (ft-transfer? miamicoin amount from to)
   )
 )
 
 (define-read-only (get-name)
-  (ok "citycoins")
+  (ok "miamicoin")
 )
 
 (define-read-only (get-symbol)
-  (ok "CYCN")
+  (ok "MIA")
 )
 
 (define-read-only (get-decimals)
@@ -49,11 +49,11 @@
 )
 
 (define-read-only (get-balance (user principal))
-  (ok (ft-get-balance citycoins user))
+  (ok (ft-get-balance miamicoin user))
 )
 
 (define-read-only (get-total-supply)
-  (ok (ft-get-supply citycoins))
+  (ok (ft-get-supply miamicoin))
 )
 
 (define-read-only (get-token-uri)
@@ -84,7 +84,7 @@
 (define-public (activate-token (coreContract principal) (stacksHeight uint))
   (let
     (
-      (coreContractMap (try! (contract-call? .citycoin-auth get-core-contract-info coreContract)))
+      (coreContractMap (try! (contract-call? .miamicoin-auth get-core-contract-info coreContract)))
     )
     (asserts! (is-eq (get state coreContractMap) STATE_ACTIVE) ERR_UNAUTHORIZED)
     (asserts! (not (var-get tokenActivated)) ERR_TOKEN_ALREADY_ACTIVATED)
@@ -117,7 +117,7 @@
 
 ;; UTILITIES
 
-(define-data-var tokenUri (optional (string-utf8 256)) (some u"https://cdn.citycoins.co/metadata/citycoin.json"))
+(define-data-var tokenUri (optional (string-utf8 256)) (some u"https://cdn.citycoins.co/metadata/miamicoin.json"))
 
 ;; set token URI to new value, only accessible by Auth
 (define-public (set-token-uri (newUri (optional (string-utf8 256))))
@@ -131,22 +131,22 @@
 (define-public (mint (amount uint) (recipient principal))
   (let
     (
-      (coreContract (try! (contract-call? .citycoin-auth get-core-contract-info contract-caller)))
+      (coreContract (try! (contract-call? .miamicoin-auth get-core-contract-info contract-caller)))
     )
-    (ft-mint? citycoins amount recipient)
+    (ft-mint? miamicoin amount recipient)
   )
 )
 
 (define-public (burn (amount uint) (owner principal))
   (begin
     (asserts! (is-eq tx-sender owner) ERR_UNAUTHORIZED)
-    (ft-burn? citycoins amount owner)
+    (ft-burn? miamicoin amount owner)
   )
 )
 
 ;; checks if caller is Auth contract
 (define-private (is-authorized-auth)
-  (is-eq contract-caller .citycoin-auth)
+  (is-eq contract-caller .miamicoin-auth)
 )
 
 ;; SEND-MANY
@@ -191,6 +191,6 @@
 (define-public (test-mint (amount uint) (recipient principal))
   (begin
     (asserts! (is-test-env) ERR_UNAUTHORIZED)
-    (ft-mint? citycoins amount recipient)
+    (ft-mint? miamicoin amount recipient)
   )
 )


### PR DESCRIPTION
This PR adds versions of MIA/NYC to local tests versus using a generic CityCoins token. This allows for simulations between multiple CityCoins as well as the ability to test upgrade mechanics.