### PR TITLE
Replace `throws` with `fails with` in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,19 +33,21 @@ After installation, the standard clarinet commands can be used against the root 
 Several commands are also available to help with testing via `npm`:
 
 - to run all tests:
-  `npm test`, `npm run test`, `npm run clarinet:test`
-- to run individual tests:
-  `npm run test:auth`
-  `npm run test:core`
-  `npm run test:tardis`
-  `npm run test:token`
-  `npm run test:utils`
-  `npm run test:vote`
+  - `npm test`
+  - `npm run test`
+  - `npm run clarinet:test`
+- to run individual tests for cities:
+  - `npm run test:mia`
+  - `npm run test:nyc`
+- to run individual tests by type:
+  - `npm run test:tardis`
+  - `npm run test:utils`
+  - `npm run test:vote`
 - to run specific clarinet functions
-  `npm run clarinet:check`
-  `npm run clarinet:codecov`
-  `npm run clarinet:costs`
-  `npm run console`, `npm run clarinet:console`
+  - `npm run clarinet:check`
+  - `npm run clarinet:codecov`
+  - `npm run clarinet:costs`
+  - `npm run console`, `npm run clarinet:console`
 
 ## Definitions, Resources, and Links
 

--- a/tests/cities/mia/miamicoin-auth-contract-management.test.ts
+++ b/tests/cities/mia/miamicoin-auth-contract-management.test.ts
@@ -130,7 +130,7 @@ describe("[MiamiCoin Auth]", () => {
           .expectUint(MiamiCoinAuthModel.ErrCode.ERR_CORE_CONTRACT_NOT_FOUND);
       });
 
-      it("throws ERR_UNAUTHORIZED if old and new contract are the same", () => {
+      it("fails with ERR_UNAUTHORIZED if old and new contract are the same", () => {
         // arrange
         const sender = accounts.get("mia_wallet")!;
         const oldContract = core.address;
@@ -223,7 +223,7 @@ describe("[MiamiCoin Auth]", () => {
     });
 
     describe("execute-upgrade-core-contract-job()", () => {
-      it("throws ERR_UNAUTHORIZED if contract-caller is not an approver", () => {
+      it("fails with ERR_UNAUTHORIZED if contract-caller is not an approver", () => {
         // arrange
         const jobId = 1;
         const sender = accounts.get("wallet_1")!;
@@ -277,7 +277,7 @@ describe("[MiamiCoin Auth]", () => {
           .expectUint(MiamiCoinAuthModel.ErrCode.ERR_UNAUTHORIZED);
       });
 
-      it("throws ERR_UNAUTHORIZED if submitted trait principal does not match job principal", () => {
+      it("fails with ERR_UNAUTHORIZED if submitted trait principal does not match job principal", () => {
         // arrange
         const jobId = 1;
         const sender = accounts.get("wallet_1")!;
@@ -331,7 +331,7 @@ describe("[MiamiCoin Auth]", () => {
           .expectUint(MiamiCoinAuthModel.ErrCode.ERR_UNAUTHORIZED);
       });
 
-      it("throws ERR_UNAUTHORIZED if old and new contract are the same", () => {
+      it("fails with ERR_UNAUTHORIZED if old and new contract are the same", () => {
         // arrange
         const jobId = 1;
         const sender = accounts.get("wallet_1")!;

--- a/tests/cities/nyc/newyorkcitycoin-auth-contract-management.test.ts
+++ b/tests/cities/nyc/newyorkcitycoin-auth-contract-management.test.ts
@@ -130,7 +130,7 @@ describe("[NewYorkCityCoin Auth]", () => {
           .expectUint(NewYorkCityCoinAuthModel.ErrCode.ERR_CORE_CONTRACT_NOT_FOUND);
       });
 
-      it("throws ERR_UNAUTHORIZED if old and new contract are the same", () => {
+      it("fails with ERR_UNAUTHORIZED if old and new contract are the same", () => {
         // arrange
         const sender = accounts.get("nyc_wallet")!;
         const oldContract = core.address;
@@ -223,7 +223,7 @@ describe("[NewYorkCityCoin Auth]", () => {
     });
 
     describe("execute-upgrade-core-contract-job()", () => {
-      it("throws ERR_UNAUTHORIZED if contract-caller is not an approver", () => {
+      it("fails with ERR_UNAUTHORIZED if contract-caller is not an approver", () => {
         // arrange
         const jobId = 1;
         const sender = accounts.get("wallet_1")!;
@@ -277,7 +277,7 @@ describe("[NewYorkCityCoin Auth]", () => {
           .expectUint(NewYorkCityCoinAuthModel.ErrCode.ERR_UNAUTHORIZED);
       });
 
-      it("throws ERR_UNAUTHORIZED if submitted trait principal does not match job principal", () => {
+      it("fails with ERR_UNAUTHORIZED if submitted trait principal does not match job principal", () => {
         // arrange
         const jobId = 1;
         const sender = accounts.get("wallet_1")!;

--- a/tests/core/citycoin-auth-contract-management.test.ts
+++ b/tests/core/citycoin-auth-contract-management.test.ts
@@ -85,7 +85,7 @@ describe("[CityCoin Auth]", () => {
           .expectUint(AuthModel.ErrCode.ERR_UNAUTHORIZED);
       });
 
-      it("throws ERR_INCORRECT_CONTRACT_STATE if new contract is not in STATE_DEPLOYED", () => {
+      it("fails with ERR_INCORRECT_CONTRACT_STATE if new contract is not in STATE_DEPLOYED", () => {
         // arrange
         const sender = accounts.get("city_wallet")!;
         const contract = core.address;
@@ -166,7 +166,7 @@ describe("[CityCoin Auth]", () => {
           .expectUint(AuthModel.ErrCode.ERR_CORE_CONTRACT_NOT_FOUND);
       });
 
-      it("throws ERR_CONTRACT_ALREADY_EXISTS if old and new contract are the same", () => {
+      it("fails with ERR_CONTRACT_ALREADY_EXISTS if old and new contract are the same", () => {
         // arrange
         const sender = accounts.get("city_wallet")!;
         const oldContract = core.address;
@@ -188,7 +188,7 @@ describe("[CityCoin Auth]", () => {
           .expectErr()
           .expectUint(AuthModel.ErrCode.ERR_CONTRACT_ALREADY_EXISTS);
       });
-      it("throws ERR_CONTRACT_ALREADY_EXISTS if called with a target contract already in core contracts map", () => {
+      it("fails with ERR_CONTRACT_ALREADY_EXISTS if called with a target contract already in core contracts map", () => {
         // arrange
         const sender = accounts.get("city_wallet")!;
         const oldContract = core.address;
@@ -282,7 +282,7 @@ describe("[CityCoin Auth]", () => {
     });
 
     describe("execute-upgrade-core-contract-job()", () => {
-      it("throws ERR_UNAUTHORIZED if contract-caller is not an approver", () => {
+      it("fails with ERR_UNAUTHORIZED if contract-caller is not an approver", () => {
         // arrange
         const jobId = 1;
         const sender = accounts.get("wallet_1")!;
@@ -336,7 +336,7 @@ describe("[CityCoin Auth]", () => {
           .expectUint(AuthModel.ErrCode.ERR_UNAUTHORIZED);
       });
 
-      it("throws ERR_UNAUTHORIZED if submitted trait principal does not match job principal", () => {
+      it("fails with ERR_UNAUTHORIZED if submitted trait principal does not match job principal", () => {
         // arrange
         const jobId = 1;
         const sender = accounts.get("wallet_1")!;
@@ -390,7 +390,7 @@ describe("[CityCoin Auth]", () => {
           .expectUint(AuthModel.ErrCode.ERR_UNAUTHORIZED);
       });
 
-      it("throws ERR_CONTRACT_ALREADY_EXISTS if old and new contract are the same", () => {
+      it("fails with ERR_CONTRACT_ALREADY_EXISTS if old and new contract are the same", () => {
         // arrange
         const jobId = 1;
         const sender = accounts.get("wallet_1")!;
@@ -442,7 +442,7 @@ describe("[CityCoin Auth]", () => {
           .expectUint(AuthModel.ErrCode.ERR_CONTRACT_ALREADY_EXISTS);
       });
 
-      it("throws ERR_CONTRACT_ALREADY_EXISTS if called with a target contract already in core contracts map", () => {
+      it("fails with ERR_CONTRACT_ALREADY_EXISTS if called with a target contract already in core contracts map", () => {
         // arrange
         const jobId = 1;
         const sender = accounts.get("wallet_1")!;


### PR DESCRIPTION
This PR makes a small change to make the test output more consistent. A successful function call should start with `succeeds` and a failed function call should start with `faills with ERR_NAME`.

Also updates the readme based on the new test structure.