### PR TITLE
Community Upgrade: upgrade/activation flow

### DIFF
--- a/contracts/cities/mia/local/miamicoin-core-v2.clar
+++ b/contracts/cities/mia/local/miamicoin-core-v2.clar
@@ -63,11 +63,8 @@
 
 ;; returns Stacks block height registration was activated at plus activationDelay
 (define-read-only (get-activation-block)
-  (let
-    (
-      (activated (var-get activationReached))
-    )
-    (asserts! activated ERR_CONTRACT_NOT_ACTIVATED)
+  (begin
+    (asserts! (get-activation-status) ERR_CONTRACT_NOT_ACTIVATED)
     (ok (var-get activationBlock))
   )
 )

--- a/contracts/cities/mia/local/miamicoin-core-v2.clar
+++ b/contracts/cities/mia/local/miamicoin-core-v2.clar
@@ -53,9 +53,11 @@
 
 ;; REGISTRATION
 
+(define-constant MIAMICOIN_ACTIVATION_HEIGHT u24497)
 (define-data-var activationBlock uint u340282366920938463463374607431768211455)
 (define-data-var activationDelay uint u150)
 (define-data-var activationReached bool false)
+(define-data-var activationTarget uint u0)
 (define-data-var activationThreshold uint u20)
 (define-data-var usersNonce uint u0)
 
@@ -78,6 +80,14 @@
 ;; returns activation status as boolean
 (define-read-only (get-activation-status)
   (var-get activationReached)
+)
+
+;; returns activation target
+(define-read-only (get-activation-target)
+  (begin
+    (asserts! (get-activation-status) ERR_CONTRACT_NOT_ACTIVATED)
+    (ok (var-get activationTarget))
+  )
 )
 
 ;; returns activation threshold
@@ -156,14 +166,15 @@
     (if (is-eq newId threshold)
       (let
         (
-          (activationBlockVal (+ block-height (var-get activationDelay)))
+          (activationTargetBlock (+ block-height (var-get activationDelay)))
         )
-        (try! (contract-call? .miamicoin-auth-v2 activate-core-contract (as-contract tx-sender) activationBlockVal))
-        (try! (contract-call? .miamicoin-token-v2 activate-token (as-contract tx-sender) activationBlockVal))
+        (try! (contract-call? .miamicoin-auth-v2 activate-core-contract (as-contract tx-sender) activationTargetBlock))
+        (try! (contract-call? .miamicoin-token-v2 activate-token (as-contract tx-sender) MIAMICOIN_ACTIVATION_HEIGHT))
         (try! (set-coinbase-thresholds))
         (try! (set-coinbase-amounts))
         (var-set activationReached true)
-        (var-set activationBlock activationBlockVal)
+        (var-set activationBlock MIAMICOIN_ACTIVATION_HEIGHT)
+        (var-set activationTarget activationTargetBlock)
         (ok true)
       )
       (ok true)
@@ -293,7 +304,7 @@
 
 (define-public (mine-many (amounts (list 200 uint)))
   (begin
-    (asserts! (get-activation-status) ERR_CONTRACT_NOT_ACTIVATED)
+    (asserts! (is-activated) ERR_CONTRACT_NOT_ACTIVATED)
     (asserts! (> (len amounts) u0) ERR_INSUFFICIENT_COMMITMENT)
     (match (fold mine-single amounts (ok { userId: (get-or-create-user-id tx-sender), toStackers: u0, toCity: u0, stacksHeight: block-height }))
       okReturn 
@@ -369,7 +380,7 @@
       )
       (toStackers (- amountUstx toCity))
     )
-    (asserts! (get-activation-status) ERR_CONTRACT_NOT_ACTIVATED)
+    (asserts! (is-activated) ERR_CONTRACT_NOT_ACTIVATED)
     (asserts! (not (has-mined-at-block stacksHeight userId)) ERR_USER_ALREADY_MINED)
     (asserts! (> amountUstx u0) ERR_INSUFFICIENT_COMMITMENT)
     (asserts! (>= (stx-get-balance tx-sender) amountUstx) ERR_INSUFFICIENT_BALANCE)
@@ -674,7 +685,7 @@
         last: (+ targetCycle lockPeriod)
       })
     )
-    (asserts! (get-activation-status) ERR_CONTRACT_NOT_ACTIVATED)
+    (asserts! (is-activated) ERR_CONTRACT_NOT_ACTIVATED)
     (asserts! (and (> lockPeriod u0) (<= lockPeriod MAX_REWARD_CYCLES))
       ERR_CANNOT_STACK)
     (asserts! (> amountTokens u0) ERR_CANNOT_STACK)
@@ -824,7 +835,7 @@
 (define-read-only (get-coinbase-thresholds)
   (let
     (
-      (activated (var-get activationReached))
+      (activated (get-activation-status))
     )
     (asserts! activated ERR_CONTRACT_NOT_ACTIVATED)
     (ok {
@@ -882,7 +893,7 @@
 (define-read-only (get-coinbase-amounts)
   (let
     (
-      (activated (var-get activationReached))
+      (activated (get-activation-status))
     )
     (asserts! activated ERR_CONTRACT_NOT_ACTIVATED)
     (ok {
@@ -988,6 +999,12 @@
 ;; checks if caller is Auth contract
 (define-private (is-authorized-auth)
   (is-eq contract-caller .miamicoin-auth-v2)
+)
+
+;; checks if contract is fully activated to
+;; enable mining and stacking functions
+(define-private (is-activated)
+  (and (get-activation-status) (>= block-height (var-get activationTarget)))
 )
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/models/cities/mia/miamicoin-core-v2.model.ts
+++ b/models/cities/mia/miamicoin-core-v2.model.ts
@@ -38,6 +38,10 @@ export class MiamiCoinCoreModelV2 extends Model {
   static readonly TOKEN_REWARD_MATURITY = 100;
   static readonly BONUS_PERIOD_LENGTH = 10000;
   static readonly MICRO_CITYCOINS = 1000000;
+  static readonly MIAMICOIN_ACTIVATION_HEIGHT = 24497;
+  // based on shutdown at 59,000
+  // and cycle 17 starting at 60,197
+  static readonly REWARD_CYCLE_OFFSET = 17;
 
   //////////////////////////////////////////////////
   // CITY WALLET MANAGEMENT
@@ -69,6 +73,10 @@ export class MiamiCoinCoreModelV2 extends Model {
 
   getActivationStatus(): ReadOnlyFn {
     return this.callReadOnly("get-activation-status");
+  }
+
+  getActivationTarget(): ReadOnlyFn {
+    return this.callReadOnly("get-activation-target");
   }
 
   getActivationThreshold(): ReadOnlyFn {

--- a/models/cities/nyc/newyorkcitycoin-core-v2.model.ts
+++ b/models/cities/nyc/newyorkcitycoin-core-v2.model.ts
@@ -38,6 +38,10 @@ export class NewYorkCityCoinCoreModelV2 extends Model {
   static readonly TOKEN_REWARD_MATURITY = 100;
   static readonly BONUS_PERIOD_LENGTH = 10000;
   static readonly MICRO_CITYCOINS = 1000000;
+  static readonly NEWYORKCITYCOIN_ACTIVATION_HEIGHT = 37449;
+  // based on shutdown at 59,000
+  // and cycle 11 starting at 60,549
+  static readonly REWARD_CYCLE_OFFSET = 11;
 
   //////////////////////////////////////////////////
   // CITY WALLET MANAGEMENT
@@ -69,6 +73,10 @@ export class NewYorkCityCoinCoreModelV2 extends Model {
 
   getActivationStatus(): ReadOnlyFn {
     return this.callReadOnly("get-activation-status");
+  }
+
+  getActivationTarget(): ReadOnlyFn {
+    return this.callReadOnly("get-activation-target");
   }
 
   getActivationThreshold(): ReadOnlyFn {

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-city-wallet-management.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-city-wallet-management.test.ts
@@ -12,6 +12,7 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   coreV2 = ctx.models.get(MiamiCoinCoreModelV2, "miamicoin-core-v2");
+  chain.mineEmptyBlock(59000);
 });
 
 describe("[MiamiCoin Core v2]", () => {

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-mining-claims.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-mining-claims.test.ts
@@ -12,6 +12,7 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   coreV2 = ctx.models.get(MiamiCoinCoreModelV2, "miamicoin-core-v2");
+  chain.mineEmptyBlock(59000);
 });
 
 describe("[MiamiCoin Core v2]", () => {
@@ -173,7 +174,9 @@ describe("[MiamiCoin Core v2]", () => {
           .expectUint(MiamiCoinCoreModelV2.ErrCode.ERR_MINER_DID_NOT_WIN);
       });
 
-      it("succeeds and mints 250,000,000,000 tokens in 1st issuance cycle, during bonus period", () => {
+      // skipped because contract will be activated based on the
+      // original block height and 250,000 bonus period is over
+      it.skip("succeeds and mints 250,000,000,000 tokens in 1st issuance cycle, during bonus period", () => {
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amount = 2;
@@ -216,12 +219,10 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(miner),
         ]);
+
         const activationBlockHeight =
           setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
-
-        chain.mineEmptyBlockUntil(
-          activationBlockHeight + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + 1
-        );
+        chain.mineEmptyBlockUntil(activationBlockHeight);
 
         const block = chain.mineBlock([coreV2.mineTokens(amount, miner)]);
         chain.mineEmptyBlock(MiamiCoinCoreModelV2.TOKEN_REWARD_MATURITY);
@@ -247,17 +248,16 @@ describe("[MiamiCoin Core v2]", () => {
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amount = 2;
-        const setupBlock = chain.mineBlock([
+        chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(miner),
         ]);
-        const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
 
-        chain.mineEmptyBlockUntil(
-          activationBlockHeight + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH + 1
-        );
+        const targetBlockHeight = MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + 
+          MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + 
+          MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH + 1;
+        chain.mineEmptyBlockUntil(targetBlockHeight);
 
         const block = chain.mineBlock([coreV2.mineTokens(amount, miner)]);
         chain.mineEmptyBlock(MiamiCoinCoreModelV2.TOKEN_REWARD_MATURITY);
@@ -283,17 +283,16 @@ describe("[MiamiCoin Core v2]", () => {
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amount = 2;
-        const setupBlock = chain.mineBlock([
+        chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(miner),
         ]);
-        const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
 
-        chain.mineEmptyBlockUntil(
-          activationBlockHeight + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 2 + 1
-        );
+        const targetBlockHeight = MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + 
+          MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + 
+          MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 2 + 1;
+        chain.mineEmptyBlockUntil(targetBlockHeight);
 
         const block = chain.mineBlock([coreV2.mineTokens(amount, miner)]);
         chain.mineEmptyBlock(MiamiCoinCoreModelV2.TOKEN_REWARD_MATURITY);
@@ -319,17 +318,16 @@ describe("[MiamiCoin Core v2]", () => {
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amount = 2;
-        const setupBlock = chain.mineBlock([
+        chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(miner),
         ]);
-        const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
 
-        chain.mineEmptyBlockUntil(
-          activationBlockHeight + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 3 + 1
-        );
+        const targetBlockHeight = MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + 
+          MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + 
+          MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 3 + 1;
+        chain.mineEmptyBlockUntil(targetBlockHeight);
 
         const block = chain.mineBlock([coreV2.mineTokens(amount, miner)]);
         chain.mineEmptyBlock(MiamiCoinCoreModelV2.TOKEN_REWARD_MATURITY);
@@ -355,17 +353,16 @@ describe("[MiamiCoin Core v2]", () => {
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amount = 2;
-        const setupBlock = chain.mineBlock([
+        chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(miner),
         ]);
-        const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
 
-        chain.mineEmptyBlockUntil(
-          activationBlockHeight + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 4 + 1
-        );
+        const targetBlockHeight = MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + 
+          MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + 
+          MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 4 + 1;
+        chain.mineEmptyBlockUntil(targetBlockHeight);
 
         const block = chain.mineBlock([coreV2.mineTokens(amount, miner)]);
         chain.mineEmptyBlock(MiamiCoinCoreModelV2.TOKEN_REWARD_MATURITY);
@@ -391,17 +388,16 @@ describe("[MiamiCoin Core v2]", () => {
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amount = 2;
-        const setupBlock = chain.mineBlock([
+        chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(miner),
         ]);
-        const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
 
-        chain.mineEmptyBlockUntil(
-          activationBlockHeight + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 5 + 1
-        );
+        const targetBlockHeight = MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + 
+          MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + 
+          MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 5 + 1;
+        chain.mineEmptyBlockUntil(targetBlockHeight);
 
         const block = chain.mineBlock([coreV2.mineTokens(amount, miner)]);
         chain.mineEmptyBlock(MiamiCoinCoreModelV2.TOKEN_REWARD_MATURITY);

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-mining-claims.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-mining-claims.test.ts
@@ -219,7 +219,6 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(miner),
         ]);
-
         const activationBlockHeight =
           setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
         chain.mineEmptyBlockUntil(activationBlockHeight);
@@ -255,7 +254,7 @@ describe("[MiamiCoin Core v2]", () => {
         ]);
 
         const targetBlockHeight = MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + 
-          MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + 
+          MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH +
           MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH + 1;
         chain.mineEmptyBlockUntil(targetBlockHeight);
 
@@ -290,7 +289,7 @@ describe("[MiamiCoin Core v2]", () => {
         ]);
 
         const targetBlockHeight = MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + 
-          MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + 
+          MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH +
           MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 2 + 1;
         chain.mineEmptyBlockUntil(targetBlockHeight);
 
@@ -325,7 +324,7 @@ describe("[MiamiCoin Core v2]", () => {
         ]);
 
         const targetBlockHeight = MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + 
-          MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + 
+          MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH +
           MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 3 + 1;
         chain.mineEmptyBlockUntil(targetBlockHeight);
 
@@ -360,7 +359,7 @@ describe("[MiamiCoin Core v2]", () => {
         ]);
 
         const targetBlockHeight = MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + 
-          MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + 
+          MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH +
           MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 4 + 1;
         chain.mineEmptyBlockUntil(targetBlockHeight);
 
@@ -395,7 +394,7 @@ describe("[MiamiCoin Core v2]", () => {
         ]);
 
         const targetBlockHeight = MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + 
-          MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + 
+          MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH +
           MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 5 + 1;
         chain.mineEmptyBlockUntil(targetBlockHeight);
 

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-mining.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-mining.test.ts
@@ -15,6 +15,7 @@ beforeEach(() => {
   accounts = ctx.accounts;
   coreV2 = ctx.models.get(MiamiCoinCoreModelV2, "miamicoin-core-v2");
   tokenV2 = ctx.models.get(MiamiCoinTokenModelV2, "miamicoin-token-v2");
+  chain.mineEmptyBlock(59000);
 });
 
 describe("[MiamiCoin Core v2]", () => {
@@ -89,10 +90,15 @@ describe("[MiamiCoin Core v2]", () => {
   //////////////////////////////////////////////////
   describe("MINING ACTIONS", () => {
     describe("mine-tokens()", () => {
-      it("fails with ERR_CONTRACT_NOT_ACTIVATED while trying to mine before reaching activation threshold", () => {
+      it("fails with ERR_CONTRACT_NOT_ACTIVATED while trying to mine before the activation target is reached", () => {
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amountUstx = 200;
+        chain.mineBlock([
+          coreV2.testInitializeCore(coreV2.address),
+          coreV2.testSetActivationThreshold(1),
+          coreV2.registerUser(miner),
+        ]);
 
         // act
         const receipt = chain.mineBlock([
@@ -109,11 +115,14 @@ describe("[MiamiCoin Core v2]", () => {
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amountUstx = 0;
-        chain.mineBlock([
+        const block = chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(miner),
         ]);
+        const activationBlockHeight =
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+        chain.mineEmptyBlock(activationBlockHeight);
 
         // act
         const receipt = chain.mineBlock([
@@ -130,11 +139,14 @@ describe("[MiamiCoin Core v2]", () => {
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amountUstx = miner.balance + 1;
-        chain.mineBlock([
+        const block = chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(miner),
         ]);
+        const activationBlockHeight =
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+        chain.mineEmptyBlock(activationBlockHeight);
 
         // act
         const receipt = chain.mineBlock([
@@ -145,27 +157,6 @@ describe("[MiamiCoin Core v2]", () => {
         receipt.result
           .expectErr()
           .expectUint(MiamiCoinCoreModelV2.ErrCode.ERR_INSUFFICIENT_BALANCE);
-      });
-
-      it("fails with ERR_STACKING_NOT_VAILABLE while trying to mine before the activation period ends", () => {
-        // arrange
-        const miner = accounts.get("wallet_2")!;
-        const amountUstx = 200;
-        chain.mineBlock([
-          coreV2.testInitializeCore(coreV2.address),
-          coreV2.testSetActivationThreshold(1),
-          coreV2.registerUser(miner),
-        ]);
-
-        // act
-        const receipt = chain.mineBlock([
-          coreV2.mineTokens(amountUstx, miner),
-        ]).receipts[0];
-
-        //assert
-        receipt.result
-          .expectErr()
-          .expectUint(MiamiCoinCoreModelV2.ErrCode.ERR_STACKING_NOT_AVAILABLE);
       });
 
       it("succeeds and emits one stx_transfer event to city wallet during first cycle", () => {
@@ -309,7 +300,7 @@ describe("[MiamiCoin Core v2]", () => {
     });
 
     describe("mine-many()", () => {
-      it("fails with ERR_CONTRACT_NOT_ACTIVATED while trying to mine before reaching activation threshold", () => {
+      it("fails with ERR_CONTRACT_NOT_ACTIVATED while trying to mine before the activation target is reached", () => {
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amounts = [1, 2, 3, 4];
@@ -322,26 +313,6 @@ describe("[MiamiCoin Core v2]", () => {
         receipt.result
           .expectErr()
           .expectUint(MiamiCoinCoreModelV2.ErrCode.ERR_CONTRACT_NOT_ACTIVATED);
-      });
-
-      it("fails with ERR_STACKING_NOT_AVAILABLE while trying to mine before activation period ends", () => {
-        // arrange
-        const miner = accounts.get("wallet_1")!;
-        const amounts = [1, 2, 3, 4];
-        chain.mineBlock([
-          coreV2.testInitializeCore(coreV2.address),
-          coreV2.testSetActivationThreshold(1),
-          coreV2.registerUser(miner),
-        ]);
-
-        // act
-        const receipt = chain.mineBlock([coreV2.mineMany(amounts, miner)])
-          .receipts[0];
-
-        // assert
-        receipt.result
-          .expectErr()
-          .expectUint(MiamiCoinCoreModelV2.ErrCode.ERR_STACKING_NOT_AVAILABLE);
       });
 
       it("fails with ERR_INSUFFICIENT_COMMITMENT while providing empty list of amounts", () => {

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-registration.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-registration.test.ts
@@ -12,6 +12,7 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   coreV2 = ctx.models.get(MiamiCoinCoreModelV2, "miamicoin-core-v2");
+  chain.mineEmptyBlock(59000);
 });
 
 describe("[MiamiCoin Core v2]", () => {
@@ -37,12 +38,10 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(user),
         ]);
-        const activationBlockHeight =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
         // act
         const result = coreV2.getActivationBlock().result;
         // assert
-        result.expectOk().expectUint(activationBlockHeight);
+        result.expectOk().expectUint(MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT);
       });
     });
     describe("get-activation-delay()", () => {
@@ -51,6 +50,33 @@ describe("[MiamiCoin Core v2]", () => {
         const result = coreV2.getActivationDelay().result;
         // assert
         result.expectUint(MiamiCoinCoreModelV2.ACTIVATION_DELAY);
+      });
+    });
+    describe("get-activation-target()", () => {
+      it("fails with ERR_CONTRACT_NOT_ACTIVATED if called before contract is activated", () => {
+        // act
+        const result = coreV2.getActivationTarget().result;
+
+        // assert
+        result
+          .expectErr()
+          .expectUint(MiamiCoinCoreModelV2.ErrCode.ERR_CONTRACT_NOT_ACTIVATED);
+      });
+      it("succeeds and returns activation target", () => {
+        // arrange
+        const user = accounts.get("wallet_4")!;
+        const block = chain.mineBlock([
+          coreV2.testInitializeCore(coreV2.address),
+          coreV2.testSetActivationThreshold(1),
+          coreV2.registerUser(user),
+        ]);
+        const activationBlockHeight =
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+        chain.mineEmptyBlock(activationBlockHeight);
+        // act
+        const result = coreV2.getActivationTarget().result;
+        // assert
+        result.expectOk().expectUint(activationBlockHeight);
       });
     });
     describe("get-activation-threshold()", () => {

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-registration.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-registration.test.ts
@@ -33,7 +33,7 @@ describe("[MiamiCoin Core v2]", () => {
       it("succeeds and returns activation height", () => {
         // arrange
         const user = accounts.get("wallet_4")!;
-        const block = chain.mineBlock([
+        chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(user),
@@ -56,7 +56,6 @@ describe("[MiamiCoin Core v2]", () => {
       it("fails with ERR_CONTRACT_NOT_ACTIVATED if called before contract is activated", () => {
         // act
         const result = coreV2.getActivationTarget().result;
-
         // assert
         result
           .expectErr()

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-stacking.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-stacking.test.ts
@@ -50,7 +50,7 @@ describe("[MiamiCoin Core v2]", () => {
         // arrange
         const stacker = accounts.get("wallet_2")!;
         const stackerId = 1;
-        const targetCycle = 1;
+        const targetCycle = MiamiCoinCoreModelV2.REWARD_CYCLE_OFFSET;
         const amountTokens = 200;
         const setupBlock = chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
@@ -312,7 +312,7 @@ describe("[MiamiCoin Core v2]", () => {
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
         // act
-        const stackingBlock = chain.mineBlock([
+        chain.mineBlock([
           coreV2.stackTokens(amountTokens, lockPeriod, stacker),
         ]);
 

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-stacking.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-stacking.test.ts
@@ -15,6 +15,7 @@ beforeEach(() => {
   accounts = ctx.accounts;
   coreV2 = ctx.models.get(MiamiCoinCoreModelV2, "miamicoin-core-v2");
   tokenV2 = ctx.models.get(MiamiCoinTokenModelV2, "miamicoin-token-v2");
+  chain.mineEmptyBlock(59000);
 });
 
 describe("[MiamiCoin Core v2]", () => {
@@ -31,17 +32,17 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(user),
         ]);
-        const activationBlockHeight =
+        const targetBlock =
           setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
-        chain.mineEmptyBlockUntil(activationBlockHeight);
+        chain.mineEmptyBlockUntil(targetBlock);
         // act
         const result1 = coreV2.getFirstStacksBlockInRewardCycle(0).result;
         const result2 = coreV2.getFirstStacksBlockInRewardCycle(1).result;
-        const result3 = coreV2.getFirstStacksBlockInRewardCycle(2).result;
+        const result3 = coreV2.getFirstStacksBlockInRewardCycle(25).result;
         // assert
-        result1.expectUint(activationBlockHeight);
-        result2.expectUint(activationBlockHeight + MiamiCoinCoreModelV2.REWARD_CYCLE_LENGTH);
-        result3.expectUint(activationBlockHeight + MiamiCoinCoreModelV2.REWARD_CYCLE_LENGTH * 2);
+        result1.expectUint(MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT);
+        result2.expectUint(MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + MiamiCoinCoreModelV2.REWARD_CYCLE_LENGTH);
+        result3.expectUint(MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + MiamiCoinCoreModelV2.REWARD_CYCLE_LENGTH * 25);
       });
     });
     describe("get-entitled-stacking-reward()", () => {
@@ -72,7 +73,7 @@ describe("[MiamiCoin Core v2]", () => {
         const amountUstx = 1000;
         const stacker = accounts.get("wallet_2")!;
         const stackerId = 1;
-        const targetCycle = 1;
+        const targetCycle = MiamiCoinCoreModelV2.REWARD_CYCLE_OFFSET;
         const amountTokens = 200;
         const setupBlock = chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
@@ -83,7 +84,7 @@ describe("[MiamiCoin Core v2]", () => {
         chain.mineEmptyBlockUntil(
           setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY + 1
         );
-        chain.mineBlock([coreV2.stackTokens(amountTokens, 1, stacker)]);
+        chain.mineBlock([coreV2.stackTokens(amountTokens, targetCycle, stacker)]);
         chain.mineEmptyBlock(MiamiCoinCoreModelV2.REWARD_CYCLE_LENGTH);
         chain.mineBlock([coreV2.mineTokens(amountUstx, miner)]);
         chain.mineEmptyBlock(MiamiCoinCoreModelV2.REWARD_CYCLE_LENGTH);
@@ -311,12 +312,12 @@ describe("[MiamiCoin Core v2]", () => {
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
         // act
-        chain.mineBlock([
+        const stackingBlock = chain.mineBlock([
           coreV2.stackTokens(amountTokens, lockPeriod, stacker),
         ]);
 
         // assert
-        const rewardCycle = 1;
+        const rewardCycle = MiamiCoinCoreModelV2.REWARD_CYCLE_OFFSET;
         const userId = 1;
         const result = coreV2.getStackerAtCycleOrDefault(
           rewardCycle,
@@ -351,8 +352,7 @@ describe("[MiamiCoin Core v2]", () => {
 
         // assert
         const userId = 1;
-
-        for (let rewardCycle = 1; rewardCycle <= lockPeriod; rewardCycle++) {
+        for (let rewardCycle = MiamiCoinCoreModelV2.REWARD_CYCLE_OFFSET; rewardCycle <= lockPeriod; rewardCycle++) {
           const result = coreV2.getStackerAtCycleOrDefault(
             rewardCycle,
             userId
@@ -369,6 +369,7 @@ describe("[MiamiCoin Core v2]", () => {
         // arrange
         const stacker = accounts.get("wallet_2")!;
         const userId = 1;
+        const cycleOffset = MiamiCoinCoreModelV2.REWARD_CYCLE_OFFSET;
         class StackingRecord {
           constructor(
             readonly stackInCycle: number,
@@ -380,9 +381,9 @@ describe("[MiamiCoin Core v2]", () => {
         const stackingRecords: StackingRecord[] = [
           new StackingRecord(1, 4, 20),
           new StackingRecord(3, 8, 432),
-          new StackingRecord(7, 3, 10),
-          new StackingRecord(8, 2, 15),
-          new StackingRecord(9, 5, 123),
+          new StackingRecord(10, 3, 10),
+          new StackingRecord(25, 2, 15),
+          new StackingRecord(32, 5, 123),
         ];
 
         const totalAmountTokens = stackingRecords.reduce(
@@ -392,7 +393,7 @@ describe("[MiamiCoin Core v2]", () => {
         const maxCycle = Math.max.apply(
           Math,
           stackingRecords.map((record) => {
-            return record.stackInCycle + 1 + record.lockPeriod;
+            return record.stackInCycle + cycleOffset + record.lockPeriod;
           })
         );
 
@@ -402,16 +403,15 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(stacker),
           tokenV2.testMint(totalAmountTokens, stacker),
         ]);
-        const activationBlockHeight =
+        const targetBlock =
           block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
-        chain.mineEmptyBlockUntil(activationBlockHeight);
+        chain.mineEmptyBlockUntil(targetBlock);
 
         // act
         stackingRecords.forEach((record) => {
           // move chain tip to the beginning of specific cycle
           chain.mineEmptyBlockUntil(
-            activationBlockHeight +
-              record.stackInCycle * MiamiCoinCoreModelV2.REWARD_CYCLE_LENGTH
+            targetBlock + record.stackInCycle * MiamiCoinCoreModelV2.REWARD_CYCLE_LENGTH
           );
 
           chain.mineBlock([
@@ -424,21 +424,21 @@ describe("[MiamiCoin Core v2]", () => {
         });
 
         // assert
-        for (let rewardCycle = 0; rewardCycle <= maxCycle; rewardCycle++) {
+        for (let rewardCycle = cycleOffset; rewardCycle <= maxCycle; rewardCycle++) {
           let expected = {
             amountStacked: 0,
             toReturn: 0,
           };
 
           stackingRecords.forEach((record) => {
-            let firstCycle = record.stackInCycle + 1;
-            let lastCycle = record.stackInCycle + record.lockPeriod;
+            let firstCycle = cycleOffset + record.stackInCycle;
+            let lastCycle = cycleOffset + record.stackInCycle + record.lockPeriod - 1;
 
             if (rewardCycle >= firstCycle && rewardCycle <= lastCycle) {
               expected.amountStacked += record.amountTokens;
             }
 
-            if (rewardCycle == lastCycle) {
+            if (rewardCycle === lastCycle) {
               expected.toReturn += record.amountTokens;
             }
           });
@@ -467,6 +467,7 @@ describe("[MiamiCoin Core v2]", () => {
         const amountTokens = 20;
         const lockPeriod = 1;
         const stackDuringCycle = 3;
+        const cycleOffset = MiamiCoinCoreModelV2.REWARD_CYCLE_OFFSET;
         const block = chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
@@ -480,7 +481,7 @@ describe("[MiamiCoin Core v2]", () => {
         const receipt = chain.mineBlock([coreV2.stackTokens(amountTokens, lockPeriod, stacker)]).receipts[0];
 
         // assert
-        const firstCycle = stackDuringCycle + 1;
+        const firstCycle = cycleOffset + stackDuringCycle;
         const lastCycle = firstCycle + (lockPeriod - 1);
         const expectedPrintMsg = `{firstCycle: ${types.uint(firstCycle)}, lastCycle: ${types.uint(lastCycle)}}`;
 
@@ -493,6 +494,7 @@ describe("[MiamiCoin Core v2]", () => {
         const amountTokens = 20;
         const lockPeriod = 9;
         const stackDuringCycle = 8;
+        const cycleOffset = MiamiCoinCoreModelV2.REWARD_CYCLE_OFFSET;
         const block = chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
@@ -506,7 +508,7 @@ describe("[MiamiCoin Core v2]", () => {
         const receipt = chain.mineBlock([coreV2.stackTokens(amountTokens, lockPeriod, stacker)]).receipts[0];
 
         // assert
-        const firstCycle = stackDuringCycle + 1;
+        const firstCycle = stackDuringCycle + cycleOffset;
         const lastCycle = firstCycle + (lockPeriod - 1);
         const expectedPrintMsg = `{firstCycle: ${types.uint(firstCycle)}, lastCycle: ${types.uint(lastCycle)}}`;
 

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-token-configuration.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-token-configuration.test.ts
@@ -35,18 +35,21 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(user)
         ]);
-        const activationBlockHeight =
+        const activationBlock = MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT;
+        const bonusPeriod = MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH;
+        const epochLength = MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH;
+        const targetBlock =
           block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
-        chain.mineEmptyBlockUntil(activationBlockHeight);
+        chain.mineEmptyBlockUntil(targetBlock);
         // act
         const result = coreV2.getCoinbaseThresholds().result;
         // assert
         const expectedResult = {
-          coinbaseThreshold1: types.uint(MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH),     // 210151
-          coinbaseThreshold2: types.uint(MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 2), // 420151
-          coinbaseThreshold3: types.uint(MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 3), // 630151
-          coinbaseThreshold4: types.uint(MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 4), // 840151
-          coinbaseThreshold5: types.uint(MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 5)  // 1050151
+          coinbaseThreshold1: types.uint(activationBlock + bonusPeriod + epochLength),     // 210151
+          coinbaseThreshold2: types.uint(activationBlock + bonusPeriod + epochLength * 2), // 420151
+          coinbaseThreshold3: types.uint(activationBlock + bonusPeriod + epochLength * 3), // 630151
+          coinbaseThreshold4: types.uint(activationBlock + bonusPeriod + epochLength * 4), // 840151
+          coinbaseThreshold5: types.uint(activationBlock + bonusPeriod + epochLength * 5)  // 1050151
         };
         assertEquals(result.expectOk().expectTuple(), expectedResult);
       });
@@ -61,6 +64,7 @@ describe("[MiamiCoin Core v2]", () => {
       it("succeeds and returns coinbase amounts", () => {
         // arrange
         const user = accounts.get("wallet_1")!;
+        const microCitycoins = MiamiCoinCoreModelV2.MICRO_CITYCOINS;
         const block = chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
@@ -73,13 +77,13 @@ describe("[MiamiCoin Core v2]", () => {
         const result = coreV2.getCoinbaseAmounts().result;
         // assert
         const expectedResult = {
-          coinbaseAmount1: types.uint(100000 * MiamiCoinCoreModelV2.MICRO_CITYCOINS),
-          coinbaseAmount2: types.uint(50000 * MiamiCoinCoreModelV2.MICRO_CITYCOINS),
-          coinbaseAmount3: types.uint(25000 * MiamiCoinCoreModelV2.MICRO_CITYCOINS),
-          coinbaseAmount4: types.uint(12500 * MiamiCoinCoreModelV2.MICRO_CITYCOINS),
-          coinbaseAmount5: types.uint(6250 * MiamiCoinCoreModelV2.MICRO_CITYCOINS),
-          coinbaseAmountBonus: types.uint(250000 * MiamiCoinCoreModelV2.MICRO_CITYCOINS),
-          coinbaseAmountDefault: types.uint(3125 * MiamiCoinCoreModelV2.MICRO_CITYCOINS),
+          coinbaseAmount1: types.uint(100000 * microCitycoins),
+          coinbaseAmount2: types.uint(50000 * microCitycoins),
+          coinbaseAmount3: types.uint(25000 * microCitycoins),
+          coinbaseAmount4: types.uint(12500 * microCitycoins),
+          coinbaseAmount5: types.uint(6250 * microCitycoins),
+          coinbaseAmountBonus: types.uint(250000 * microCitycoins),
+          coinbaseAmountDefault: types.uint(3125 * microCitycoins),
         };
         assertEquals(result.expectOk().expectTuple(), expectedResult);
       });

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-token-configuration.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-token-configuration.test.ts
@@ -12,6 +12,7 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   coreV2 = ctx.models.get(MiamiCoinCoreModelV2, "miamicoin-core-v2");
+  chain.mineEmptyBlock(59000);
 });
 
 describe("[MiamiCoin Core v2]", () => {
@@ -41,11 +42,11 @@ describe("[MiamiCoin Core v2]", () => {
         const result = coreV2.getCoinbaseThresholds().result;
         // assert
         const expectedResult = {
-          coinbaseThreshold1: types.uint(activationBlockHeight + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH),     // 210151
-          coinbaseThreshold2: types.uint(activationBlockHeight + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 2), // 420151
-          coinbaseThreshold3: types.uint(activationBlockHeight + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 3), // 630151
-          coinbaseThreshold4: types.uint(activationBlockHeight + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 4), // 840151
-          coinbaseThreshold5: types.uint(activationBlockHeight + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 5)  // 1050151
+          coinbaseThreshold1: types.uint(MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH),     // 210151
+          coinbaseThreshold2: types.uint(MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 2), // 420151
+          coinbaseThreshold3: types.uint(MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 3), // 630151
+          coinbaseThreshold4: types.uint(MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 4), // 840151
+          coinbaseThreshold5: types.uint(MiamiCoinCoreModelV2.MIAMICOIN_ACTIVATION_HEIGHT + MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH + MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 5)  // 1050151
         };
         assertEquals(result.expectOk().expectTuple(), expectedResult);
       });

--- a/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-city-wallet-management.test.ts
+++ b/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-city-wallet-management.test.ts
@@ -12,6 +12,7 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   coreV2 = ctx.models.get(NewYorkCityCoinCoreModelV2, "newyorkcitycoin-core-v2");
+  chain.mineEmptyBlock(59000);
 });
 
 describe("[NewYorkCityCoin Core v2]", () => {

--- a/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-mining-claims.test.ts
+++ b/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-mining-claims.test.ts
@@ -12,6 +12,7 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   coreV2 = ctx.models.get(NewYorkCityCoinCoreModelV2, "newyorkcitycoin-core-v2");
+  chain.mineEmptyBlock(59000);
 });
 
 describe("[NewYorkCityCoin Core v2]", () => {
@@ -173,7 +174,9 @@ describe("[NewYorkCityCoin Core v2]", () => {
           .expectUint(NewYorkCityCoinCoreModelV2.ErrCode.ERR_MINER_DID_NOT_WIN);
       });
 
-      it("succeeds and mints 250,000,000,000 tokens in 1st issuance cycle, during bonus period", () => {
+      // skipped because contract will be activated based on the
+      // original block height and 250,000 bonus period is over
+      it.skip("succeeds and mints 250,000,000,000 tokens in 1st issuance cycle, during bonus period", () => {
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amount = 2;
@@ -218,10 +221,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
         ]);
         const activationBlockHeight =
           setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
-
-        chain.mineEmptyBlockUntil(
-          activationBlockHeight + NewYorkCityCoinCoreModelV2.BONUS_PERIOD_LENGTH + 1
-        );
+        chain.mineEmptyBlockUntil(activationBlockHeight);
 
         const block = chain.mineBlock([coreV2.mineTokens(amount, miner)]);
         chain.mineEmptyBlock(NewYorkCityCoinCoreModelV2.TOKEN_REWARD_MATURITY);
@@ -247,17 +247,16 @@ describe("[NewYorkCityCoin Core v2]", () => {
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amount = 2;
-        const setupBlock = chain.mineBlock([
+        chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(miner),
         ]);
-        const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
 
-        chain.mineEmptyBlockUntil(
-          activationBlockHeight + NewYorkCityCoinCoreModelV2.BONUS_PERIOD_LENGTH + NewYorkCityCoinCoreModelV2.TOKEN_EPOCH_LENGTH + 1
-        );
+        const targetBlockHeight = NewYorkCityCoinCoreModelV2.NEWYORKCITYCOIN_ACTIVATION_HEIGHT +
+          NewYorkCityCoinCoreModelV2.BONUS_PERIOD_LENGTH +
+          NewYorkCityCoinCoreModelV2.TOKEN_EPOCH_LENGTH + 1;
+        chain.mineEmptyBlockUntil(targetBlockHeight);
 
         const block = chain.mineBlock([coreV2.mineTokens(amount, miner)]);
         chain.mineEmptyBlock(NewYorkCityCoinCoreModelV2.TOKEN_REWARD_MATURITY);
@@ -283,17 +282,16 @@ describe("[NewYorkCityCoin Core v2]", () => {
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amount = 2;
-        const setupBlock = chain.mineBlock([
+        chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(miner),
         ]);
-        const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
 
-        chain.mineEmptyBlockUntil(
-          activationBlockHeight + NewYorkCityCoinCoreModelV2.BONUS_PERIOD_LENGTH + NewYorkCityCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 2 + 1
-        );
+        const targetBlockHeight = NewYorkCityCoinCoreModelV2.NEWYORKCITYCOIN_ACTIVATION_HEIGHT +
+          NewYorkCityCoinCoreModelV2.BONUS_PERIOD_LENGTH +
+          NewYorkCityCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 2 + 1;
+        chain.mineEmptyBlockUntil(targetBlockHeight);
 
         const block = chain.mineBlock([coreV2.mineTokens(amount, miner)]);
         chain.mineEmptyBlock(NewYorkCityCoinCoreModelV2.TOKEN_REWARD_MATURITY);
@@ -319,17 +317,16 @@ describe("[NewYorkCityCoin Core v2]", () => {
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amount = 2;
-        const setupBlock = chain.mineBlock([
+        chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(miner),
         ]);
-        const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
 
-        chain.mineEmptyBlockUntil(
-          activationBlockHeight + NewYorkCityCoinCoreModelV2.BONUS_PERIOD_LENGTH + NewYorkCityCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 3 + 1
-        );
+        const targetBlockHeight = NewYorkCityCoinCoreModelV2.NEWYORKCITYCOIN_ACTIVATION_HEIGHT +
+          NewYorkCityCoinCoreModelV2.BONUS_PERIOD_LENGTH +
+          NewYorkCityCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 3 + 1;
+        chain.mineEmptyBlockUntil(targetBlockHeight);
 
         const block = chain.mineBlock([coreV2.mineTokens(amount, miner)]);
         chain.mineEmptyBlock(NewYorkCityCoinCoreModelV2.TOKEN_REWARD_MATURITY);
@@ -355,17 +352,16 @@ describe("[NewYorkCityCoin Core v2]", () => {
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amount = 2;
-        const setupBlock = chain.mineBlock([
+        chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(miner),
         ]);
-        const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
 
-        chain.mineEmptyBlockUntil(
-          activationBlockHeight + NewYorkCityCoinCoreModelV2.BONUS_PERIOD_LENGTH + NewYorkCityCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 4 + 1
-        );
+        const targetBlockHeight = NewYorkCityCoinCoreModelV2.NEWYORKCITYCOIN_ACTIVATION_HEIGHT +
+          NewYorkCityCoinCoreModelV2.BONUS_PERIOD_LENGTH +
+          NewYorkCityCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 4 + 1;
+        chain.mineEmptyBlockUntil(targetBlockHeight);
 
         const block = chain.mineBlock([coreV2.mineTokens(amount, miner)]);
         chain.mineEmptyBlock(NewYorkCityCoinCoreModelV2.TOKEN_REWARD_MATURITY);
@@ -391,17 +387,16 @@ describe("[NewYorkCityCoin Core v2]", () => {
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amount = 2;
-        const setupBlock = chain.mineBlock([
+        chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(miner),
         ]);
-        const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
 
-        chain.mineEmptyBlockUntil(
-          activationBlockHeight + NewYorkCityCoinCoreModelV2.BONUS_PERIOD_LENGTH + NewYorkCityCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 5 + 1
-        );
+        const targetBlockHeight = NewYorkCityCoinCoreModelV2.NEWYORKCITYCOIN_ACTIVATION_HEIGHT +
+          NewYorkCityCoinCoreModelV2.BONUS_PERIOD_LENGTH +
+          NewYorkCityCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 5 + 1;
+        chain.mineEmptyBlockUntil(targetBlockHeight);
 
         const block = chain.mineBlock([coreV2.mineTokens(amount, miner)]);
         chain.mineEmptyBlock(NewYorkCityCoinCoreModelV2.TOKEN_REWARD_MATURITY);

--- a/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-registration.test.ts
+++ b/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-registration.test.ts
@@ -12,6 +12,7 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   coreV2 = ctx.models.get(NewYorkCityCoinCoreModelV2, "newyorkcitycoin-core-v2");
+  chain.mineEmptyBlock(59000);
 });
 
 describe("[NewYorkCityCoin Core v2]", () => {
@@ -32,17 +33,15 @@ describe("[NewYorkCityCoin Core v2]", () => {
       it("succeeds and returns activation height", () => {
         // arrange
         const user = accounts.get("wallet_4")!;
-        const block = chain.mineBlock([
+        chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(user),
         ]);
-        const activationBlockHeight =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
         // act
         const result = coreV2.getActivationBlock().result;
         // assert
-        result.expectOk().expectUint(activationBlockHeight);
+        result.expectOk().expectUint(NewYorkCityCoinCoreModelV2.NEWYORKCITYCOIN_ACTIVATION_HEIGHT);
       });
     });
     describe("get-activation-delay()", () => {
@@ -51,6 +50,32 @@ describe("[NewYorkCityCoin Core v2]", () => {
         const result = coreV2.getActivationDelay().result;
         // assert
         result.expectUint(NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY);
+      });
+    });
+    describe("get-activation-target()", () => {
+      it("fails with ERR_CONTRACT_NOT_ACTIVATED if called before contract is activated", () => {
+        // act
+        const result = coreV2.getActivationTarget().result;
+        // assert
+        result
+          .expectErr()
+          .expectUint(NewYorkCityCoinCoreModelV2.ErrCode.ERR_CONTRACT_NOT_ACTIVATED);
+      });
+      it("succeeds and returns activation target", () => {
+        // arrange
+        const user = accounts.get("wallet_4")!;
+        const block = chain.mineBlock([
+          coreV2.testInitializeCore(coreV2.address),
+          coreV2.testSetActivationThreshold(1),
+          coreV2.registerUser(user),
+        ]);
+        const activationBlockHeight =
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+        chain.mineEmptyBlockUntil(activationBlockHeight);
+        // act
+        const result = coreV2.getActivationTarget().result;
+        // assert
+        result.expectOk().expectUint(activationBlockHeight);
       });
     });
     describe("get-activation-threshold()", () => {

--- a/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-stacking-claims.test.ts
+++ b/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-stacking-claims.test.ts
@@ -15,6 +15,7 @@ beforeEach(() => {
   accounts = ctx.accounts;
   coreV2 = ctx.models.get(NewYorkCityCoinCoreModelV2, "newyorkcitycoin-core-v2");
   tokenV2 = ctx.models.get(NewYorkCityCoinTokenModelV2, "newyorkcitycoin-token-v2");
+  chain.mineEmptyBlock(59000);
 });
 
 describe("[NewYorkCityCoin Core v2]", () => {
@@ -23,11 +24,19 @@ describe("[NewYorkCityCoin Core v2]", () => {
   //////////////////////////////////////////////////
   describe("STACKING CLAIMS", () => {
     describe("claim-stacking-reward()", () => {
-      it("fails with ERR_STACKING_NOT_AVAILABLE when stacking is not yet available", () => {
+      // skipped because stacking will be available
+      // based on the activation height in the past
+      it.skip("fails with ERR_STACKING_NOT_AVAILABLE when stacking is not yet available", () => {
         // arrange
         const stacker = accounts.get("wallet_1")!;
+        const amount = 500;
+        chain.mineBlock([
+          coreV2.testInitializeCore(coreV2.address),
+          coreV2.testSetActivationThreshold(1),
+          coreV2.registerUser(stacker),
+          tokenV2.testMint(amount, stacker),
+        ]);
         const targetCycle = 1;
-
         // act
         const receipt = chain.mineBlock([
           coreV2.claimStackingReward(targetCycle, stacker),
@@ -67,7 +76,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
       it("fails with ERR_REWARD_CYCLE_NOT_COMPLETED when reward cycle is not completed", () => {
         // arrange
         const stacker = accounts.get("wallet_1")!;
-        const targetCycle = 1;
+        const targetCycle = NewYorkCityCoinCoreModelV2.REWARD_CYCLE_OFFSET;
         const setupBlock = chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
@@ -91,7 +100,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
       it("fails with ERR_NOTHING_TO_REDEEM when stacker didn't stack at all", () => {
         // arrange
         const stacker = accounts.get("wallet_1")!;
-        const targetCycle = 1;
+        const targetCycle = NewYorkCityCoinCoreModelV2.REWARD_CYCLE_OFFSET;
         const setupBlock = chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
@@ -118,7 +127,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
       it("fails with ERR_NOTHING_TO_REDEEM when stacker stacked in a cycle but miners did not mine", () => {
         // arrange
         const stacker = accounts.get("wallet_1")!;
-        const targetCycle = 1;
+        const targetCycle = NewYorkCityCoinCoreModelV2.REWARD_CYCLE_OFFSET;
         const amount = 200;
         const setupBlock = chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
@@ -146,7 +155,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
       it("fails with ERR_NOTHING_TO_REDEEM while trying to claim reward 2nd time", () => {
         // arrange
         const stacker = accounts.get("wallet_1")!;
-        const targetCycle = 1;
+        const targetCycle = NewYorkCityCoinCoreModelV2.REWARD_CYCLE_OFFSET;
         const amount = 200;
         const setupBlock = chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
@@ -177,7 +186,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
         const miner = accounts.get("wallet_1")!;
         const amountUstx = 1000;
         const stacker = accounts.get("wallet_2")!;
-        const targetCycle = 1;
+        const targetCycle = NewYorkCityCoinCoreModelV2.REWARD_CYCLE_OFFSET;
         const amountTokens = 200;
         const setupBlock = chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
@@ -220,7 +229,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
         // arrange
         const stacker = accounts.get("wallet_1")!;
         const amountTokens = 20;
-        const targetCycle = 1;
+        const targetCycle = NewYorkCityCoinCoreModelV2.REWARD_CYCLE_OFFSET;
         const setupBlock = chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
@@ -254,7 +263,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
       it("succeeds and returns tokens only for last cycle in locked period", () => {
         // arrange
         const stacker = accounts.get("wallet_2")!;
-        const userId = 1;
+        const cycleOffset = NewYorkCityCoinCoreModelV2.REWARD_CYCLE_OFFSET;
         class StackingRecord {
           constructor(
             readonly stackInCycle: number,
@@ -288,15 +297,14 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(stacker),
           tokenV2.testMint(totalAmountTokens, stacker),
         ]);
-        const activationBlockHeight =
+        const targetBlock =
           block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
-        chain.mineEmptyBlockUntil(activationBlockHeight);
+        chain.mineEmptyBlockUntil(targetBlock);
 
         stackingRecords.forEach((record) => {
           // move chain tip to the beginning of specific cycle
           chain.mineEmptyBlockUntil(
-            activationBlockHeight +
-              record.stackInCycle * NewYorkCityCoinCoreModelV2.REWARD_CYCLE_LENGTH
+            targetBlock + record.stackInCycle * NewYorkCityCoinCoreModelV2.REWARD_CYCLE_LENGTH
           );
 
           chain.mineBlock([
@@ -309,15 +317,15 @@ describe("[NewYorkCityCoin Core v2]", () => {
         });
 
         chain.mineEmptyBlockUntil(
-          NewYorkCityCoinCoreModelV2.REWARD_CYCLE_LENGTH * (maxCycle + 1)
+          targetBlock + NewYorkCityCoinCoreModelV2.REWARD_CYCLE_LENGTH * (maxCycle + 1)
         );
 
         // act + assert
-        for (let rewardCycle = 0; rewardCycle <= maxCycle; rewardCycle++) {
+        for (let rewardCycle = cycleOffset; rewardCycle <= maxCycle; rewardCycle++) {
           let toReturn = 0;
 
           stackingRecords.forEach((record) => {
-            let lastCycle = record.stackInCycle + record.lockPeriod;
+            let lastCycle = cycleOffset + record.stackInCycle + record.lockPeriod - 1;
 
             if (rewardCycle == lastCycle) {
               toReturn += record.amountTokens;

--- a/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-stacking.test.ts
+++ b/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-stacking.test.ts
@@ -15,6 +15,7 @@ beforeEach(() => {
   accounts = ctx.accounts;
   coreV2 = ctx.models.get(NewYorkCityCoinCoreModelV2, "newyorkcitycoin-core-v2");
   tokenV2 = ctx.models.get(NewYorkCityCoinTokenModelV2, "newyorkcitycoin-token-v2");
+  chain.mineEmptyBlock(59000);
 });
 
 describe("[NewYorkCityCoin Core v2]", () => {
@@ -31,17 +32,17 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(user),
         ]);
-        const activationBlockHeight =
+        const targetBlock =
           setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
-        chain.mineEmptyBlockUntil(activationBlockHeight);
+        chain.mineEmptyBlockUntil(targetBlock);
         // act
         const result1 = coreV2.getFirstStacksBlockInRewardCycle(0).result;
         const result2 = coreV2.getFirstStacksBlockInRewardCycle(1).result;
-        const result3 = coreV2.getFirstStacksBlockInRewardCycle(2).result;
+        const result3 = coreV2.getFirstStacksBlockInRewardCycle(25).result;
         // assert
-        result1.expectUint(activationBlockHeight);
-        result2.expectUint(activationBlockHeight + NewYorkCityCoinCoreModelV2.REWARD_CYCLE_LENGTH);
-        result3.expectUint(activationBlockHeight + NewYorkCityCoinCoreModelV2.REWARD_CYCLE_LENGTH * 2);
+        result1.expectUint(NewYorkCityCoinCoreModelV2.NEWYORKCITYCOIN_ACTIVATION_HEIGHT);
+        result2.expectUint(NewYorkCityCoinCoreModelV2.NEWYORKCITYCOIN_ACTIVATION_HEIGHT + NewYorkCityCoinCoreModelV2.REWARD_CYCLE_LENGTH);
+        result3.expectUint(NewYorkCityCoinCoreModelV2.NEWYORKCITYCOIN_ACTIVATION_HEIGHT + NewYorkCityCoinCoreModelV2.REWARD_CYCLE_LENGTH * 25);
       });
     });
     describe("get-entitled-stacking-reward()", () => {
@@ -49,7 +50,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
         // arrange
         const stacker = accounts.get("wallet_2")!;
         const stackerId = 1;
-        const targetCycle = 1;
+        const targetCycle = NewYorkCityCoinCoreModelV2.REWARD_CYCLE_OFFSET;
         const amountTokens = 200;
         const setupBlock = chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
@@ -72,7 +73,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
         const amountUstx = 1000;
         const stacker = accounts.get("wallet_2")!;
         const stackerId = 1;
-        const targetCycle = 1;
+        const targetCycle = NewYorkCityCoinCoreModelV2.REWARD_CYCLE_OFFSET;
         const amountTokens = 200;
         const setupBlock = chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
@@ -83,7 +84,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
         chain.mineEmptyBlockUntil(
           setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY + 1
         );
-        chain.mineBlock([coreV2.stackTokens(amountTokens, 1, stacker)]);
+        chain.mineBlock([coreV2.stackTokens(amountTokens, targetCycle, stacker)]);
         chain.mineEmptyBlock(NewYorkCityCoinCoreModelV2.REWARD_CYCLE_LENGTH);
         chain.mineBlock([coreV2.mineTokens(amountUstx, miner)]);
         chain.mineEmptyBlock(NewYorkCityCoinCoreModelV2.REWARD_CYCLE_LENGTH);
@@ -316,7 +317,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
         ]);
 
         // assert
-        const rewardCycle = 1;
+        const rewardCycle = NewYorkCityCoinCoreModelV2.REWARD_CYCLE_OFFSET;
         const userId = 1;
         const result = coreV2.getStackerAtCycleOrDefault(
           rewardCycle,
@@ -351,8 +352,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
 
         // assert
         const userId = 1;
-
-        for (let rewardCycle = 1; rewardCycle <= lockPeriod; rewardCycle++) {
+        for (let rewardCycle = NewYorkCityCoinCoreModelV2.REWARD_CYCLE_OFFSET; rewardCycle <= lockPeriod; rewardCycle++) {
           const result = coreV2.getStackerAtCycleOrDefault(
             rewardCycle,
             userId
@@ -369,6 +369,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
         // arrange
         const stacker = accounts.get("wallet_2")!;
         const userId = 1;
+        const cycleOffset = NewYorkCityCoinCoreModelV2.REWARD_CYCLE_OFFSET;
         class StackingRecord {
           constructor(
             readonly stackInCycle: number,
@@ -380,9 +381,9 @@ describe("[NewYorkCityCoin Core v2]", () => {
         const stackingRecords: StackingRecord[] = [
           new StackingRecord(1, 4, 20),
           new StackingRecord(3, 8, 432),
-          new StackingRecord(7, 3, 10),
-          new StackingRecord(8, 2, 15),
-          new StackingRecord(9, 5, 123),
+          new StackingRecord(10, 3, 10),
+          new StackingRecord(25, 2, 15),
+          new StackingRecord(32, 5, 123),
         ];
 
         const totalAmountTokens = stackingRecords.reduce(
@@ -392,7 +393,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
         const maxCycle = Math.max.apply(
           Math,
           stackingRecords.map((record) => {
-            return record.stackInCycle + 1 + record.lockPeriod;
+            return record.stackInCycle + cycleOffset + record.lockPeriod;
           })
         );
 
@@ -402,16 +403,15 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(stacker),
           tokenV2.testMint(totalAmountTokens, stacker),
         ]);
-        const activationBlockHeight =
+        const targetBlock =
           block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
-        chain.mineEmptyBlockUntil(activationBlockHeight);
+        chain.mineEmptyBlockUntil(targetBlock);
 
         // act
         stackingRecords.forEach((record) => {
           // move chain tip to the beginning of specific cycle
           chain.mineEmptyBlockUntil(
-            activationBlockHeight +
-              record.stackInCycle * NewYorkCityCoinCoreModelV2.REWARD_CYCLE_LENGTH
+            targetBlock + record.stackInCycle * NewYorkCityCoinCoreModelV2.REWARD_CYCLE_LENGTH
           );
 
           chain.mineBlock([
@@ -424,21 +424,21 @@ describe("[NewYorkCityCoin Core v2]", () => {
         });
 
         // assert
-        for (let rewardCycle = 0; rewardCycle <= maxCycle; rewardCycle++) {
+        for (let rewardCycle = cycleOffset; rewardCycle <= maxCycle; rewardCycle++) {
           let expected = {
             amountStacked: 0,
             toReturn: 0,
           };
 
           stackingRecords.forEach((record) => {
-            let firstCycle = record.stackInCycle + 1;
-            let lastCycle = record.stackInCycle + record.lockPeriod;
+            let firstCycle = cycleOffset + record.stackInCycle;
+            let lastCycle = cycleOffset + record.stackInCycle + record.lockPeriod - 1;
 
             if (rewardCycle >= firstCycle && rewardCycle <= lastCycle) {
               expected.amountStacked += record.amountTokens;
             }
 
-            if (rewardCycle == lastCycle) {
+            if (rewardCycle === lastCycle) {
               expected.toReturn += record.amountTokens;
             }
           });
@@ -467,6 +467,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
         const amountTokens = 20;
         const lockPeriod = 1;
         const stackDuringCycle = 3;
+        const cycleOffset = NewYorkCityCoinCoreModelV2.REWARD_CYCLE_OFFSET;
         const block = chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
@@ -480,7 +481,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
         const receipt = chain.mineBlock([coreV2.stackTokens(amountTokens, lockPeriod, stacker)]).receipts[0];
 
         // assert
-        const firstCycle = stackDuringCycle + 1;
+        const firstCycle = cycleOffset + stackDuringCycle;
         const lastCycle = firstCycle + (lockPeriod - 1);
         const expectedPrintMsg = `{firstCycle: ${types.uint(firstCycle)}, lastCycle: ${types.uint(lastCycle)}}`;
 
@@ -493,6 +494,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
         const amountTokens = 20;
         const lockPeriod = 9;
         const stackDuringCycle = 8;
+        const cycleOffset = NewYorkCityCoinCoreModelV2.REWARD_CYCLE_OFFSET;
         const block = chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
@@ -506,7 +508,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
         const receipt = chain.mineBlock([coreV2.stackTokens(amountTokens, lockPeriod, stacker)]).receipts[0];
 
         // assert
-        const firstCycle = stackDuringCycle + 1;
+        const firstCycle = stackDuringCycle + cycleOffset;
         const lastCycle = firstCycle + (lockPeriod - 1);
         const expectedPrintMsg = `{firstCycle: ${types.uint(firstCycle)}, lastCycle: ${types.uint(lastCycle)}}`;
 

--- a/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-token-configuration.test.ts
+++ b/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-token-configuration.test.ts
@@ -12,6 +12,7 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   coreV2 = ctx.models.get(NewYorkCityCoinCoreModelV2, "newyorkcitycoin-core-v2");
+  chain.mineEmptyBlock(59000);
 });
 
 describe("[NewYorkCityCoin Core v2]", () => {
@@ -34,18 +35,21 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(user)
         ]);
-        const activationBlockHeight =
+        const activationBlock = NewYorkCityCoinCoreModelV2.NEWYORKCITYCOIN_ACTIVATION_HEIGHT;
+        const bonusPeriod = NewYorkCityCoinCoreModelV2.BONUS_PERIOD_LENGTH;
+        const epochLength = NewYorkCityCoinCoreModelV2.TOKEN_EPOCH_LENGTH;
+        const targetBlock =
           block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
-        chain.mineEmptyBlockUntil(activationBlockHeight);
+        chain.mineEmptyBlockUntil(targetBlock);
         // act
         const result = coreV2.getCoinbaseThresholds().result;
         // assert
         const expectedResult = {
-          coinbaseThreshold1: types.uint(activationBlockHeight + NewYorkCityCoinCoreModelV2.BONUS_PERIOD_LENGTH + NewYorkCityCoinCoreModelV2.TOKEN_EPOCH_LENGTH),     // 210151
-          coinbaseThreshold2: types.uint(activationBlockHeight + NewYorkCityCoinCoreModelV2.BONUS_PERIOD_LENGTH + NewYorkCityCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 2), // 420151
-          coinbaseThreshold3: types.uint(activationBlockHeight + NewYorkCityCoinCoreModelV2.BONUS_PERIOD_LENGTH + NewYorkCityCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 3), // 630151
-          coinbaseThreshold4: types.uint(activationBlockHeight + NewYorkCityCoinCoreModelV2.BONUS_PERIOD_LENGTH + NewYorkCityCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 4), // 840151
-          coinbaseThreshold5: types.uint(activationBlockHeight + NewYorkCityCoinCoreModelV2.BONUS_PERIOD_LENGTH + NewYorkCityCoinCoreModelV2.TOKEN_EPOCH_LENGTH * 5)  // 1050151
+          coinbaseThreshold1: types.uint(activationBlock + bonusPeriod + epochLength),     // 210151
+          coinbaseThreshold2: types.uint(activationBlock + bonusPeriod + epochLength * 2), // 420151
+          coinbaseThreshold3: types.uint(activationBlock + bonusPeriod + epochLength * 3), // 630151
+          coinbaseThreshold4: types.uint(activationBlock + bonusPeriod + epochLength * 4), // 840151
+          coinbaseThreshold5: types.uint(activationBlock + bonusPeriod + epochLength * 5)  // 1050151
         };
         assertEquals(result.expectOk().expectTuple(), expectedResult);
       });
@@ -60,6 +64,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
       it("succeeds and returns coinbase amounts", () => {
         // arrange
         const user = accounts.get("wallet_1")!;
+        const microCitycoins = NewYorkCityCoinCoreModelV2.MICRO_CITYCOINS;
         const block = chain.mineBlock([
           coreV2.testInitializeCore(coreV2.address),
           coreV2.testSetActivationThreshold(1),
@@ -72,13 +77,13 @@ describe("[NewYorkCityCoin Core v2]", () => {
         const result = coreV2.getCoinbaseAmounts().result;
         // assert
         const expectedResult = {
-          coinbaseAmount1: types.uint(100000 * NewYorkCityCoinCoreModelV2.MICRO_CITYCOINS),
-          coinbaseAmount2: types.uint(50000 * NewYorkCityCoinCoreModelV2.MICRO_CITYCOINS),
-          coinbaseAmount3: types.uint(25000 * NewYorkCityCoinCoreModelV2.MICRO_CITYCOINS),
-          coinbaseAmount4: types.uint(12500 * NewYorkCityCoinCoreModelV2.MICRO_CITYCOINS),
-          coinbaseAmount5: types.uint(6250 * NewYorkCityCoinCoreModelV2.MICRO_CITYCOINS),
-          coinbaseAmountBonus: types.uint(250000 * NewYorkCityCoinCoreModelV2.MICRO_CITYCOINS),
-          coinbaseAmountDefault: types.uint(3125 * NewYorkCityCoinCoreModelV2.MICRO_CITYCOINS),
+          coinbaseAmount1: types.uint(100000 * microCitycoins),
+          coinbaseAmount2: types.uint(50000 * microCitycoins),
+          coinbaseAmount3: types.uint(25000 * microCitycoins),
+          coinbaseAmount4: types.uint(12500 * microCitycoins),
+          coinbaseAmount5: types.uint(6250 * microCitycoins),
+          coinbaseAmountBonus: types.uint(250000 * microCitycoins),
+          coinbaseAmountDefault: types.uint(3125 * microCitycoins),
         };
         assertEquals(result.expectOk().expectTuple(), expectedResult);
       });


### PR DESCRIPTION
This PR separates the activation block from the target block to start mining and stacking, so that:

- MIA/NYC can be set with an activation block in the past, making the emissions schedule continue where we left off (this affects the coinbase thresholds)
- MIA/NYC can set a target block for mining/stacking, so that if a delay is needed when shutting down V1, it is set independently of the activation block