### PR TITLE
Update activation delay

### DIFF
--- a/contracts/cities/mia/local/miamicoin-core-v2.clar
+++ b/contracts/cities/mia/local/miamicoin-core-v2.clar
@@ -55,7 +55,7 @@
 
 (define-constant MIAMICOIN_ACTIVATION_HEIGHT u24497)
 (define-data-var activationBlock uint u340282366920938463463374607431768211455)
-(define-data-var activationDelay uint u150)
+(define-data-var activationDelay uint u0)
 (define-data-var activationReached bool false)
 (define-data-var activationTarget uint u0)
 (define-data-var activationThreshold uint u20)

--- a/contracts/cities/nyc/local/newyorkcitycoin-core-v2.clar
+++ b/contracts/cities/nyc/local/newyorkcitycoin-core-v2.clar
@@ -55,7 +55,7 @@
 
 (define-constant NEWYORKCITYCOIN_ACTIVATION_HEIGHT u37449)
 (define-data-var activationBlock uint u340282366920938463463374607431768211455)
-(define-data-var activationDelay uint u150)
+(define-data-var activationDelay uint u0)
 (define-data-var activationReached bool false)
 (define-data-var activationTarget uint u0)
 (define-data-var activationThreshold uint u20)

--- a/models/cities/mia/miamicoin-core-v2.model.ts
+++ b/models/cities/mia/miamicoin-core-v2.model.ts
@@ -30,7 +30,7 @@ export class MiamiCoinCoreModelV2 extends Model {
   name = "miamicoin-core-v2"
 
   static readonly ErrCode = ErrCode;
-  static readonly ACTIVATION_DELAY = 150;
+  static readonly ACTIVATION_DELAY = 0;
   static readonly ACTIVATION_THRESHOLD = 20;
   static readonly TOKEN_EPOCH_LENGTH = 25000;
   static readonly REWARD_CYCLE_LENGTH = 2100;

--- a/models/cities/nyc/newyorkcitycoin-core-v2.model.ts
+++ b/models/cities/nyc/newyorkcitycoin-core-v2.model.ts
@@ -30,7 +30,7 @@ export class NewYorkCityCoinCoreModelV2 extends Model {
   name = "newyorkcitycoin-core-v2"
 
   static readonly ErrCode = ErrCode;
-  static readonly ACTIVATION_DELAY = 150;
+  static readonly ACTIVATION_DELAY = 0;
   static readonly ACTIVATION_THRESHOLD = 20;
   static readonly TOKEN_EPOCH_LENGTH = 25000;
   static readonly REWARD_CYCLE_LENGTH = 2100;

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-mining-claims.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-mining-claims.test.ts
@@ -67,7 +67,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -96,7 +96,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -123,7 +123,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -153,7 +153,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -186,7 +186,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -220,7 +220,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
         const block = chain.mineBlock([coreV2.mineTokens(amount, miner)]);
@@ -465,7 +465,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -492,7 +492,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -520,7 +520,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -558,7 +558,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -629,7 +629,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -656,7 +656,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -684,7 +684,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -722,7 +722,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -760,7 +760,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-mining.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-mining.test.ts
@@ -35,15 +35,12 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(miner),
           coreV2.registerUser(miner2),
         ]);
-        const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
-
-        chain.mineEmptyBlockUntil(activationBlockHeight);
 
         const block = chain.mineBlock([
           coreV2.mineTokens(amount, miner),
           coreV2.mineTokens(amount * 1000, miner2),
         ]);
+        console.log(`block: ${JSON.stringify(block)}`);
         chain.mineEmptyBlock(MiamiCoinCoreModelV2.TOKEN_REWARD_MATURITY);
 
         // act
@@ -64,7 +61,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(miner2),
         ]);
         const activationBlockHeight =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -90,7 +87,24 @@ describe("[MiamiCoin Core v2]", () => {
   //////////////////////////////////////////////////
   describe("MINING ACTIONS", () => {
     describe("mine-tokens()", () => {
-      it("fails with ERR_CONTRACT_NOT_ACTIVATED while trying to mine before the activation target is reached", () => {
+      it("fails with ERR_CONTRACT_NOT_ACTIVATED while trying to mine the contract is initialized", () => {
+        // arrange
+        const miner = accounts.get("wallet_2")!;
+        const amountUstx = 200;
+
+        // act
+        const receipt = chain.mineBlock([
+          coreV2.mineTokens(amountUstx, miner),
+        ]).receipts[0];
+
+        // assert
+        receipt.result
+          .expectErr()
+          .expectUint(MiamiCoinCoreModelV2.ErrCode.ERR_CONTRACT_NOT_ACTIVATED);
+      });
+      it.skip("fails with ERR_CONTRACT_NOT_ACTIVATED while trying to mine before the activation target is reached", () => {
+        // skipped because upgraded deployment will have 0 blocks
+        // for the activation delay (target = same as upgrade block)
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amountUstx = 200;
@@ -121,7 +135,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         const activationBlockHeight =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlock(activationBlockHeight);
 
         // act
@@ -145,7 +159,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         const activationBlockHeight =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlock(activationBlockHeight);
 
         // act
@@ -171,7 +185,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         chain.mineEmptyBlockUntil(
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY
         );
 
         // act
@@ -204,7 +218,7 @@ describe("[MiamiCoin Core v2]", () => {
         ]);
 
         const activationBlockHeight =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         const cycle1FirstBlockHeight =
           activationBlockHeight + MiamiCoinCoreModelV2.REWARD_CYCLE_LENGTH;
 
@@ -246,7 +260,7 @@ describe("[MiamiCoin Core v2]", () => {
         ]);
 
         const activationBlockHeight =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -283,7 +297,7 @@ describe("[MiamiCoin Core v2]", () => {
         ]);
 
         const activationBlockHeight =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -300,10 +314,29 @@ describe("[MiamiCoin Core v2]", () => {
     });
 
     describe("mine-many()", () => {
-      it("fails with ERR_CONTRACT_NOT_ACTIVATED while trying to mine before the activation target is reached", () => {
+      it("fails with ERR_CONTRACT_NOT_ACTIVATED while trying to mine before the contract is initialized", () => {
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amounts = [1, 2, 3, 4];
+
+        // act
+        const receipt = chain.mineBlock([coreV2.mineMany(amounts, miner)])
+          .receipts[0];
+
+        // assert
+        receipt.result
+          .expectErr()
+          .expectUint(MiamiCoinCoreModelV2.ErrCode.ERR_CONTRACT_NOT_ACTIVATED);
+      });
+      it.skip("fails with ERR_CONTRACT_NOT_ACTIVATED while trying to mine before the activation target is reached", () => {
+        // arrange
+        const miner = accounts.get("wallet_2")!;
+        const amounts = [1, 2, 3, 4];
+        chain.mineBlock([
+          coreV2.testInitializeCore(coreV2.address),
+          coreV2.testSetActivationThreshold(1),
+          coreV2.registerUser(miner),
+        ]);
 
         // act
         const receipt = chain.mineBlock([coreV2.mineMany(amounts, miner)])
@@ -325,7 +358,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         chain.mineEmptyBlockUntil(
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY
         );
 
         // act
@@ -348,7 +381,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         chain.mineEmptyBlockUntil(
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY
         );
 
         // act
@@ -371,7 +404,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         chain.mineEmptyBlockUntil(
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY
         );
 
         // act
@@ -394,7 +427,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         chain.mineEmptyBlockUntil(
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY
         );
 
         // act
@@ -417,7 +450,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         chain.mineEmptyBlockUntil(
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY
         );
         chain.mineBlock([coreV2.mineMany(amounts, miner)]);
 
@@ -442,7 +475,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         chain.mineEmptyBlockUntil(
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY
         );
 
         // act
@@ -472,7 +505,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         chain.mineEmptyBlockUntil(
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY
         );
 
         // act
@@ -507,7 +540,7 @@ describe("[MiamiCoin Core v2]", () => {
         ]);
 
         const activationBlockHeight =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         const cycle1FirstBlockHeight =
           activationBlockHeight + MiamiCoinCoreModelV2.REWARD_CYCLE_LENGTH;
 
@@ -554,7 +587,7 @@ describe("[MiamiCoin Core v2]", () => {
         ]);
 
         const activationBlockHeight =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         const cycle1FirstBlockHeight =
           activationBlockHeight + MiamiCoinCoreModelV2.REWARD_CYCLE_LENGTH;
 
@@ -596,7 +629,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         chain.mineEmptyBlockUntil(
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY
         );
 
         // act
@@ -620,7 +653,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(miner),
         ]);
-        chain.mineEmptyBlockUntil(setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1);
+        chain.mineEmptyBlockUntil(setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY);
 
         // act
         const block = chain.mineBlock([coreV2.mineMany(amounts, miner)]);

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-registration.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-registration.test.ts
@@ -70,12 +70,12 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const activationBlockHeight =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlock(activationBlockHeight);
         // act
         const result = coreV2.getActivationTarget().result;
         // assert
-        result.expectOk().expectUint(activationBlockHeight);
+        result.expectOk().expectUint(activationBlockHeight - 1);
       });
     });
     describe("get-activation-threshold()", () => {

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-stacking-claims.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-stacking-claims.test.ts
@@ -59,7 +59,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(otherUser),
         ]);
         chain.mineEmptyBlockUntil(
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY
         );
 
         // act
@@ -83,7 +83,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(stacker),
         ]);
         chain.mineEmptyBlockUntil(
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY
         );
 
         // act
@@ -298,7 +298,7 @@ describe("[MiamiCoin Core v2]", () => {
           tokenV2.testMint(totalAmountTokens, stacker),
         ]);
         const targetBlock =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(targetBlock);
 
         stackingRecords.forEach((record) => {

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-stacking.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-stacking.test.ts
@@ -33,7 +33,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const targetBlock =
-          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(targetBlock);
         // act
         const result1 = coreV2.getFirstStacksBlockInRewardCycle(0).result;
@@ -131,7 +131,7 @@ describe("[MiamiCoin Core v2]", () => {
           tokenV2.testMint(amountTokens, stacker),
         ]);
         const activationBlockHeight =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
         // act
@@ -157,7 +157,7 @@ describe("[MiamiCoin Core v2]", () => {
           tokenV2.testMint(amountTokens, stacker),
         ]);
         const activationBlockHeight =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
         // act
@@ -183,7 +183,7 @@ describe("[MiamiCoin Core v2]", () => {
           tokenV2.testMint(amountTokens, stacker),
         ]);
         const activationBlockHeight =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
         // act
@@ -209,7 +209,7 @@ describe("[MiamiCoin Core v2]", () => {
           tokenV2.testMint(amountTokens, stacker),
         ]);
         const activationBlockHeight =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
         // act
@@ -235,7 +235,7 @@ describe("[MiamiCoin Core v2]", () => {
           tokenV2.testMint(amountTokens, stacker),
         ]);
         const activationBlockHeight =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
         // act
@@ -267,7 +267,7 @@ describe("[MiamiCoin Core v2]", () => {
           tokenV2.testMint(amountTokens * 3, stacker),
         ]);
         const activationBlockHeight =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
         // act
@@ -308,7 +308,7 @@ describe("[MiamiCoin Core v2]", () => {
           tokenV2.testMint(amountTokens, stacker),
         ]);
         const activationBlockHeight =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
         // act
@@ -342,7 +342,7 @@ describe("[MiamiCoin Core v2]", () => {
           tokenV2.testMint(amountTokens, stacker),
         ]);
         const activationBlockHeight =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
         // act
@@ -404,7 +404,7 @@ describe("[MiamiCoin Core v2]", () => {
           tokenV2.testMint(totalAmountTokens, stacker),
         ]);
         const targetBlock =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(targetBlock);
 
         // act
@@ -474,7 +474,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(stacker),
           tokenV2.testMint(amountTokens, stacker),
         ]);
-        const activationBlockHeight = block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+        const activationBlockHeight = block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight + MiamiCoinCoreModelV2.REWARD_CYCLE_LENGTH * stackDuringCycle);
 
         // act
@@ -501,7 +501,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(stacker),
           tokenV2.testMint(amountTokens, stacker),
         ]);
-        const activationBlockHeight = block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+        const activationBlockHeight = block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight + MiamiCoinCoreModelV2.REWARD_CYCLE_LENGTH * stackDuringCycle);
 
         // act

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-token-configuration.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-token-configuration.test.ts
@@ -39,7 +39,7 @@ describe("[MiamiCoin Core v2]", () => {
         const bonusPeriod = MiamiCoinCoreModelV2.BONUS_PERIOD_LENGTH;
         const epochLength = MiamiCoinCoreModelV2.TOKEN_EPOCH_LENGTH;
         const targetBlock =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(targetBlock);
         // act
         const result = coreV2.getCoinbaseThresholds().result;
@@ -71,7 +71,7 @@ describe("[MiamiCoin Core v2]", () => {
           coreV2.registerUser(user)
         ]);
         const activationBlockHeight =
-          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight);
         // act
         const result = coreV2.getCoinbaseAmounts().result;

--- a/tests/cities/mia/upgrade/miamicoin-core-v1-v2.test.ts
+++ b/tests/cities/mia/upgrade/miamicoin-core-v1-v2.test.ts
@@ -64,7 +64,7 @@ describe("[MiamiCoin Upgrade v1-v2]", () => {
       core.testSetActivationThreshold(1),
       core.registerUser(sender),
     ]);
-    const activationBlock = setupBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+    const activationBlock = setupBlock.height + MiamiCoinCoreModel.ACTIVATION_DELAY - 1;
     chain.mineEmptyBlockUntil(activationBlock);
 
     // mine tokens for claim in past
@@ -166,7 +166,7 @@ describe("[MiamiCoin Upgrade v1-v2]", () => {
       coreV2.testSetActivationThreshold(1),
       coreV2.registerUser(sender),
     ]);
-    const activationBlockUpgrade = upgradeBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+    const activationBlockUpgrade = upgradeBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
     chain.mineEmptyBlockUntil(activationBlockUpgrade);
   });
 
@@ -209,7 +209,7 @@ describe("[MiamiCoin Upgrade v1-v2]", () => {
       coreV2.registerUser(user)
     ]);
     const activationBlockHeight =
-      block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1;
+      block.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY;
     chain.mineEmptyBlockUntil(activationBlockHeight);
     // act
     const result = coreV2.getCoinbaseAmounts().result;
@@ -375,6 +375,7 @@ describe("[MiamiCoin Upgrade v1-v2]", () => {
     // arrange
     const targetBlock1 = upgradeTarget - 2;
     const targetBlock2 = upgradeTarget - 1;
+    chain.mineEmptyBlock(MiamiCoinCoreModelV2.TOKEN_REWARD_MATURITY);
     // act
     const block = chain.mineBlock([
       core.claimMiningReward(targetBlock1, user1),

--- a/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-mining-claims.test.ts
+++ b/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-mining-claims.test.ts
@@ -67,7 +67,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -96,7 +96,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -123,7 +123,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -153,7 +153,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -186,7 +186,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -220,7 +220,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
         const block = chain.mineBlock([coreV2.mineTokens(amount, miner)]);
@@ -465,7 +465,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -492,7 +492,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -520,7 +520,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -558,7 +558,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -629,7 +629,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -656,7 +656,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -684,7 +684,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -722,7 +722,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -760,7 +760,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 

--- a/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-mining.test.ts
+++ b/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-mining.test.ts
@@ -315,7 +315,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
     });
 
     describe("mine-many()", () => {
-      it("fails with ERR_CONTRACT_NOT_ACTIVATED while trying to mine the before the contract is initialized", () => {
+      it("fails with ERR_CONTRACT_NOT_ACTIVATED while trying to mine before the contract is initialized", () => {
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amounts = [1, 2, 3, 4];

--- a/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-mining.test.ts
+++ b/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-mining.test.ts
@@ -36,7 +36,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(miner2),
         ]);
         const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -64,7 +64,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(miner2),
         ]);
         const activationBlockHeight =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -90,7 +90,22 @@ describe("[NewYorkCityCoin Core v2]", () => {
   //////////////////////////////////////////////////
   describe("MINING ACTIONS", () => {
     describe("mine-tokens()", () => {
-      it("fails with ERR_CONTRACT_NOT_ACTIVATED while trying to mine before the activation target is reached", () => {
+      it("fails with ERR_CONTRACT_NOT_ACTIVATED while trying to mine before the contract is initialized", () => {
+        // arrange
+        const miner = accounts.get("wallet_2")!;
+        const amountUstx = 200;
+
+        // act
+        const receipt = chain.mineBlock([
+          coreV2.mineTokens(amountUstx, miner),
+        ]).receipts[0];
+
+        // assert
+        receipt.result
+          .expectErr()
+          .expectUint(NewYorkCityCoinCoreModelV2.ErrCode.ERR_CONTRACT_NOT_ACTIVATED);
+      });
+      it.skip("fails with ERR_CONTRACT_NOT_ACTIVATED while trying to mine before the activation target is reached", () => {
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amountUstx = 200;
@@ -121,7 +136,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         const activationBlockHeight =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlock(activationBlockHeight);
 
         // act
@@ -145,7 +160,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         const activationBlockHeight =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlock(activationBlockHeight);
 
         // act
@@ -171,7 +186,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         chain.mineEmptyBlockUntil(
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY
         );
 
         // act
@@ -204,7 +219,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
         ]);
 
         const activationBlockHeight =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
         const cycle1FirstBlockHeight =
           activationBlockHeight + NewYorkCityCoinCoreModelV2.REWARD_CYCLE_LENGTH;
 
@@ -246,7 +261,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
         ]);
 
         const activationBlockHeight =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -283,7 +298,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
         ]);
 
         const activationBlockHeight =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
 
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
@@ -300,11 +315,32 @@ describe("[NewYorkCityCoin Core v2]", () => {
     });
 
     describe("mine-many()", () => {
-      it("fails with ERR_CONTRACT_NOT_ACTIVATED while trying to mine before the activation target is reached", () => {
+      it("fails with ERR_CONTRACT_NOT_ACTIVATED while trying to mine the before the contract is initialized", () => {
         // arrange
         const miner = accounts.get("wallet_2")!;
         const amounts = [1, 2, 3, 4];
 
+        // act
+        const receipt = chain.mineBlock([coreV2.mineMany(amounts, miner)])
+          .receipts[0];
+
+        // assert
+        receipt.result
+          .expectErr()
+          .expectUint(NewYorkCityCoinCoreModelV2.ErrCode.ERR_CONTRACT_NOT_ACTIVATED);
+      });
+      it.skip("fails with ERR_CONTRACT_NOT_ACTIVATED while trying to mine before the activation target is reached", () => {
+        // skipped because upgraded deployment will have 0 blocks
+        // for the activation delay (target = same as upgrade block)
+        // arrange
+        const miner = accounts.get("wallet_2")!;
+        const amounts = [1, 2, 3, 4];
+        chain.mineBlock([
+          coreV2.testInitializeCore(coreV2.address),
+          coreV2.testSetActivationThreshold(1),
+          coreV2.registerUser(miner),
+        ]);
+        
         // act
         const receipt = chain.mineBlock([coreV2.mineMany(amounts, miner)])
           .receipts[0];
@@ -325,7 +361,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         chain.mineEmptyBlockUntil(
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY
         );
 
         // act
@@ -348,7 +384,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         chain.mineEmptyBlockUntil(
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY
         );
 
         // act
@@ -371,7 +407,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         chain.mineEmptyBlockUntil(
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY
         );
 
         // act
@@ -394,7 +430,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         chain.mineEmptyBlockUntil(
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY
         );
 
         // act
@@ -417,7 +453,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         chain.mineEmptyBlockUntil(
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY
         );
         chain.mineBlock([coreV2.mineMany(amounts, miner)]);
 
@@ -442,7 +478,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         chain.mineEmptyBlockUntil(
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY
         );
 
         // act
@@ -472,7 +508,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         chain.mineEmptyBlockUntil(
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY
         );
 
         // act
@@ -507,7 +543,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
         ]);
 
         const activationBlockHeight =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
         const cycle1FirstBlockHeight =
           activationBlockHeight + NewYorkCityCoinCoreModelV2.REWARD_CYCLE_LENGTH;
 
@@ -554,7 +590,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
         ]);
 
         const activationBlockHeight =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
         const cycle1FirstBlockHeight =
           activationBlockHeight + NewYorkCityCoinCoreModelV2.REWARD_CYCLE_LENGTH;
 
@@ -596,7 +632,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(miner),
         ]);
         chain.mineEmptyBlockUntil(
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY
         );
 
         // act
@@ -620,7 +656,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(miner),
         ]);
-        chain.mineEmptyBlockUntil(setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1);
+        chain.mineEmptyBlockUntil(setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY);
 
         // act
         const block = chain.mineBlock([coreV2.mineMany(amounts, miner)]);

--- a/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-registration.test.ts
+++ b/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-registration.test.ts
@@ -70,12 +70,12 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const activationBlockHeight =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight);
         // act
         const result = coreV2.getActivationTarget().result;
         // assert
-        result.expectOk().expectUint(activationBlockHeight);
+        result.expectOk().expectUint(activationBlockHeight - 1);
       });
     });
     describe("get-activation-threshold()", () => {

--- a/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-stacking-claims.test.ts
+++ b/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-stacking-claims.test.ts
@@ -59,7 +59,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(otherUser),
         ]);
         chain.mineEmptyBlockUntil(
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY
         );
 
         // act
@@ -83,7 +83,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(stacker),
         ]);
         chain.mineEmptyBlockUntil(
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY
         );
 
         // act
@@ -298,7 +298,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           tokenV2.testMint(totalAmountTokens, stacker),
         ]);
         const targetBlock =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(targetBlock);
 
         stackingRecords.forEach((record) => {

--- a/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-stacking.test.ts
+++ b/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-stacking.test.ts
@@ -33,7 +33,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(user),
         ]);
         const targetBlock =
-          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(targetBlock);
         // act
         const result1 = coreV2.getFirstStacksBlockInRewardCycle(0).result;
@@ -131,7 +131,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           tokenV2.testMint(amountTokens, stacker),
         ]);
         const activationBlockHeight =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
         // act
@@ -157,7 +157,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           tokenV2.testMint(amountTokens, stacker),
         ]);
         const activationBlockHeight =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
         // act
@@ -183,7 +183,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           tokenV2.testMint(amountTokens, stacker),
         ]);
         const activationBlockHeight =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
         // act
@@ -209,7 +209,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           tokenV2.testMint(amountTokens, stacker),
         ]);
         const activationBlockHeight =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
         // act
@@ -235,7 +235,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           tokenV2.testMint(amountTokens, stacker),
         ]);
         const activationBlockHeight =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
         // act
@@ -267,7 +267,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           tokenV2.testMint(amountTokens * 3, stacker),
         ]);
         const activationBlockHeight =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
         // act
@@ -308,7 +308,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           tokenV2.testMint(amountTokens, stacker),
         ]);
         const activationBlockHeight =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
         // act
@@ -342,7 +342,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           tokenV2.testMint(amountTokens, stacker),
         ]);
         const activationBlockHeight =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight);
 
         // act
@@ -404,7 +404,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           tokenV2.testMint(totalAmountTokens, stacker),
         ]);
         const targetBlock =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(targetBlock);
 
         // act
@@ -474,7 +474,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(stacker),
           tokenV2.testMint(amountTokens, stacker),
         ]);
-        const activationBlockHeight = block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+        const activationBlockHeight = block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight + NewYorkCityCoinCoreModelV2.REWARD_CYCLE_LENGTH * stackDuringCycle);
 
         // act
@@ -501,7 +501,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(stacker),
           tokenV2.testMint(amountTokens, stacker),
         ]);
-        const activationBlockHeight = block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+        const activationBlockHeight = block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
         chain.mineEmptyBlockUntil(activationBlockHeight + NewYorkCityCoinCoreModelV2.REWARD_CYCLE_LENGTH * stackDuringCycle);
 
         // act

--- a/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-token-configuration.test.ts
+++ b/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-token-configuration.test.ts
@@ -39,7 +39,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
         const bonusPeriod = NewYorkCityCoinCoreModelV2.BONUS_PERIOD_LENGTH;
         const epochLength = NewYorkCityCoinCoreModelV2.TOKEN_EPOCH_LENGTH;
         const targetBlock =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY ;
         chain.mineEmptyBlockUntil(targetBlock);
         // act
         const result = coreV2.getCoinbaseThresholds().result;
@@ -71,7 +71,7 @@ describe("[NewYorkCityCoin Core v2]", () => {
           coreV2.registerUser(user)
         ]);
         const activationBlockHeight =
-          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+          block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY ;
         chain.mineEmptyBlockUntil(activationBlockHeight);
         // act
         const result = coreV2.getCoinbaseAmounts().result;

--- a/tests/cities/nyc/upgrade/newyorkcitycoin-core-v1-v2.test.ts
+++ b/tests/cities/nyc/upgrade/newyorkcitycoin-core-v1-v2.test.ts
@@ -64,7 +64,7 @@ describe("[NewYorkCityCoin Upgrade v1-v2]", () => {
       core.testSetActivationThreshold(1),
       core.registerUser(sender),
     ]);
-    const activationBlock = setupBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+    const activationBlock = setupBlock.height + NewYorkCityCoinCoreModel.ACTIVATION_DELAY - 1;
     chain.mineEmptyBlockUntil(activationBlock);
 
     // mine tokens for claim in past
@@ -166,7 +166,7 @@ describe("[NewYorkCityCoin Upgrade v1-v2]", () => {
       coreV2.testSetActivationThreshold(1),
       coreV2.registerUser(sender),
     ]);
-    const activationBlockUpgrade = upgradeBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+    const activationBlockUpgrade = upgradeBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
     chain.mineEmptyBlockUntil(activationBlockUpgrade);
   });
 
@@ -209,7 +209,7 @@ describe("[NewYorkCityCoin Upgrade v1-v2]", () => {
       coreV2.registerUser(user)
     ]);
     const activationBlockHeight =
-      block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1;
+      block.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY;
     chain.mineEmptyBlockUntil(activationBlockHeight);
     // act
     const result = coreV2.getCoinbaseAmounts().result;
@@ -375,6 +375,7 @@ describe("[NewYorkCityCoin Upgrade v1-v2]", () => {
     // arrange
     const targetBlock1 = upgradeTarget - 2;
     const targetBlock2 = upgradeTarget - 1;
+    chain.mineEmptyBlock(NewYorkCityCoinCoreModelV2.TOKEN_REWARD_MATURITY);
     // act
     const block = chain.mineBlock([
       core.claimMiningReward(targetBlock1, user1),


### PR DESCRIPTION
This PR updates the activation delay in the `core-v2` contracts from 150 blocks to 0 blocks.

This way mining can begin as soon as 20 users register, following the shutdown of the `core-v1` contracts.