### PR TITLE
Update clarinet library

### DIFF
--- a/contracts/base/local/citycoin-auth.clar
+++ b/contracts/base/local/citycoin-auth.clar
@@ -576,7 +576,7 @@
 (define-constant DEPLOYED_AT block-height)
 
 (define-private (is-test-env)
-  (is-eq DEPLOYED_AT u0)
+  (<= DEPLOYED_AT u5)
 )
 
 (define-public (test-initialize-contracts (coreContract <coreTrait>))

--- a/contracts/base/local/citycoin-core-v1.clar
+++ b/contracts/base/local/citycoin-core-v1.clar
@@ -906,7 +906,7 @@
 (define-constant DEPLOYED_AT block-height)
 
 (define-private (is-test-env)
-  (is-eq DEPLOYED_AT u0)
+  (<= DEPLOYED_AT u5)
 )
 
 (use-trait coreTrait .citycoin-core-trait.citycoin-core)

--- a/contracts/base/local/citycoin-core-v2.clar
+++ b/contracts/base/local/citycoin-core-v2.clar
@@ -916,7 +916,7 @@
 (define-constant DEPLOYED_AT block-height)
 
 (define-private (is-test-env)
-  (is-eq DEPLOYED_AT u0)
+  (<= DEPLOYED_AT u5)
 )
 
 (use-trait coreTrait .citycoin-core-trait.citycoin-core)

--- a/contracts/base/local/citycoin-token.clar
+++ b/contracts/base/local/citycoin-token.clar
@@ -185,7 +185,7 @@
 (define-constant DEPLOYED_AT block-height)
 
 (define-private (is-test-env)
-  (is-eq DEPLOYED_AT u0)
+  (<= DEPLOYED_AT u5)
 )
 
 (define-public (test-mint (amount uint) (recipient principal))

--- a/contracts/cities/mia/local/miamicoin-auth-v2.clar
+++ b/contracts/cities/mia/local/miamicoin-auth-v2.clar
@@ -646,7 +646,7 @@
 (define-constant DEPLOYED_AT block-height)
 
 (define-private (is-test-env)
-  (is-eq DEPLOYED_AT u0)
+  (<= DEPLOYED_AT u5)
 )
 
 (define-public (test-initialize-contracts (coreContract <coreTraitV2>))

--- a/contracts/cities/mia/local/miamicoin-auth.clar
+++ b/contracts/cities/mia/local/miamicoin-auth.clar
@@ -581,7 +581,7 @@
 (define-constant DEPLOYED_AT block-height)
 
 (define-private (is-test-env)
-  (is-eq DEPLOYED_AT u0)
+  (<= DEPLOYED_AT u5)
 )
 
 (define-public (test-initialize-contracts (coreContract <coreTrait>))

--- a/contracts/cities/mia/local/miamicoin-core-v1.clar
+++ b/contracts/cities/mia/local/miamicoin-core-v1.clar
@@ -899,7 +899,7 @@
 (define-constant DEPLOYED_AT block-height)
 
 (define-private (is-test-env)
-  (is-eq DEPLOYED_AT u0)
+  (<= DEPLOYED_AT u5)
 )
 
 (use-trait coreTrait .citycoin-core-trait.citycoin-core)

--- a/contracts/cities/mia/local/miamicoin-core-v2.clar
+++ b/contracts/cities/mia/local/miamicoin-core-v2.clar
@@ -1015,7 +1015,7 @@
 (define-constant DEPLOYED_AT block-height)
 
 (define-private (is-test-env)
-  (is-eq DEPLOYED_AT u0)
+  (<= DEPLOYED_AT u5)
 )
 
 (use-trait coreTraitV2 .citycoin-core-v2-trait.citycoin-core-v2)

--- a/contracts/cities/mia/local/miamicoin-token-v2.clar
+++ b/contracts/cities/mia/local/miamicoin-token-v2.clar
@@ -310,7 +310,7 @@
 (define-constant DEPLOYED_AT block-height)
 
 (define-private (is-test-env)
-  (is-eq DEPLOYED_AT u0)
+  (<= DEPLOYED_AT u5)
 )
 
 (define-public (test-mint (amount uint) (recipient principal))

--- a/contracts/cities/mia/local/miamicoin-token.clar
+++ b/contracts/cities/mia/local/miamicoin-token.clar
@@ -189,7 +189,7 @@
 (define-constant DEPLOYED_AT block-height)
 
 (define-private (is-test-env)
-  (is-eq DEPLOYED_AT u0)
+  (<= DEPLOYED_AT u5)
 )
 
 (define-public (test-mint (amount uint) (recipient principal))

--- a/contracts/cities/nyc/local/newyorkcitycoin-auth-v2.clar
+++ b/contracts/cities/nyc/local/newyorkcitycoin-auth-v2.clar
@@ -646,7 +646,7 @@
 (define-constant DEPLOYED_AT block-height)
 
 (define-private (is-test-env)
-  (is-eq DEPLOYED_AT u0)
+  (<= DEPLOYED_AT u5)
 )
 
 (define-public (test-initialize-contracts (coreContract <coreTraitV2>))

--- a/contracts/cities/nyc/local/newyorkcitycoin-auth.clar
+++ b/contracts/cities/nyc/local/newyorkcitycoin-auth.clar
@@ -580,7 +580,7 @@
 (define-constant DEPLOYED_AT block-height)
 
 (define-private (is-test-env)
-  (is-eq DEPLOYED_AT u0)
+  (<= DEPLOYED_AT u5)
 )
 
 (define-public (test-initialize-contracts (coreContract <coreTrait>))

--- a/contracts/cities/nyc/local/newyorkcitycoin-core-v1.clar
+++ b/contracts/cities/nyc/local/newyorkcitycoin-core-v1.clar
@@ -907,7 +907,7 @@
 (define-constant DEPLOYED_AT block-height)
 
 (define-private (is-test-env)
-  (is-eq DEPLOYED_AT u0)
+  (<= DEPLOYED_AT u5)
 )
 
 (use-trait coreTrait .citycoin-core-trait.citycoin-core)

--- a/contracts/cities/nyc/local/newyorkcitycoin-core-v2.clar
+++ b/contracts/cities/nyc/local/newyorkcitycoin-core-v2.clar
@@ -1015,7 +1015,7 @@
 (define-constant DEPLOYED_AT block-height)
 
 (define-private (is-test-env)
-  (is-eq DEPLOYED_AT u0)
+  (<= DEPLOYED_AT u5)
 )
 
 (use-trait coreTraitV2 .citycoin-core-v2-trait.citycoin-core-v2)

--- a/contracts/cities/nyc/local/newyorkcitycoin-token-v2.clar
+++ b/contracts/cities/nyc/local/newyorkcitycoin-token-v2.clar
@@ -310,7 +310,7 @@
 (define-constant DEPLOYED_AT block-height)
 
 (define-private (is-test-env)
-  (is-eq DEPLOYED_AT u0)
+  (<= DEPLOYED_AT u5)
 )
 
 (define-public (test-mint (amount uint) (recipient principal))

--- a/contracts/cities/nyc/local/newyorkcitycoin-token.clar
+++ b/contracts/cities/nyc/local/newyorkcitycoin-token.clar
@@ -186,7 +186,7 @@
 (define-constant DEPLOYED_AT block-height)
 
 (define-private (is-test-env)
-  (is-eq DEPLOYED_AT u0)
+  (<= DEPLOYED_AT u5)
 )
 
 (define-public (test-mint (amount uint) (recipient principal))

--- a/deps.ts
+++ b/deps.ts
@@ -2,13 +2,14 @@ export type {
   Account,
   ReadOnlyFn,
   TxReceipt,
-} from "https://deno.land/x/clarinet@v0.18.3/index.ts";
+  Block
+} from "https://deno.land/x/clarinet@v1.0.0-beta1/index.ts";
 
 export {
   Chain,
   Tx,
   types,
-} from "https://deno.land/x/clarinet@v0.18.3/index.ts";
+} from "https://deno.land/x/clarinet@v1.0.0-beta1/index.ts";
 
 export { assertEquals } from "https://deno.land/std@0.113.0/testing/asserts.ts";
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "citycoin",
-  "version": "1.1.0",
-  "description": "A smart contract implementation of the Proof of Transfer consensus mechanism, allowing for the mining and Stacking of a new fungible token on the Stacks blockchain with a portion of miner rewards going to a custodied account for a city to claim the protocol contribution.",
+  "version": "2.0.0",
+  "description": "CityCoins give communities the power to improve and program their cities.",
   "scripts": {
     "console": "clarinet console",
     "test": "npm run test:cities && npm run test:base && npm run test:misc",

--- a/src/context.ts
+++ b/src/context.ts
@@ -13,15 +13,11 @@ export class Context {
   constructor(preSetupTx?: Array<Tx>) {
     (Deno as any).core.ops();
 
-    var transactions: Array<Tx> = [];
-    if (preSetupTx) {
-      transactions = preSetupTx!;
-    }
-
     let result = JSON.parse(
-      (Deno as any).core.opSync("setup_chain", {
+      (Deno as any).core.opSync("api/v1/new_session", {
         name: "test",
-        transactions: transactions,
+        loadDeployment: true,
+        deploymentPath: null,
       })
     );
     this.chain = new Chain(result["session_id"]);
@@ -37,5 +33,13 @@ export class Context {
     this.deployer = this.accounts.get("deployer")!;
 
     this.models = new Models(this.chain, this.deployer);
+  }
+
+  terminate() {
+    JSON.parse(
+      (Deno as any).core.opSync("api/v1/terminate_session", {
+        sessionId: this.chain.sessionId,
+      })
+    );
   }
 }

--- a/tests/base/auth/citycoin-auth-city-wallet-management.test.ts
+++ b/tests/base/auth/citycoin-auth-city-wallet-management.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, beforeEach, it} from "../../../deps.ts";
+import { describe, run, Chain, beforeEach, it, afterEach} from "../../../deps.ts";
 import { Accounts, Context } from "../../../src/context.ts";
 import { AuthModel } from "../../../models/base/auth.model.ts";
 import { CoreModel } from "../../../models/base/core.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   auth = ctx.models.get(AuthModel);
   core = ctx.models.get(CoreModel, "citycoin-core-v1");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[CityCoin Auth]", () => {
   //////////////////////////////////////////////////

--- a/tests/base/auth/citycoin-auth-contract-management.test.ts
+++ b/tests/base/auth/citycoin-auth-contract-management.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it} from "../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach} from "../../../deps.ts";
 import { Accounts, Context } from "../../../src/context.ts";
 import { AuthModel } from "../../../models/base/auth.model.ts";
 import { CoreModel } from "../../../models/base/core.model.ts";
@@ -21,6 +21,10 @@ beforeEach(() => {
   core2 = ctx.models.get(CoreModel, "citycoin-core-v2");
   core3 = ctx.models.get(CoreModel, "citycoin-core-v3");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[CityCoin Auth]", () => {
   //////////////////////////////////////////////////
@@ -240,7 +244,7 @@ describe("[CityCoin Auth]", () => {
         const oldContract = core.address;
         const newContract = core2.address;
 
-        chain.mineBlock([
+        let activationBlock = chain.mineBlock([
           core.testInitializeCore(oldContract),
           core.testSetActivationThreshold(1),
           core.registerUser(sender),
@@ -265,7 +269,7 @@ describe("[CityCoin Auth]", () => {
 
         const expectedOldContractData = {
           state: types.uint(AuthModel.ContractState.STATE_INACTIVE),
-          startHeight: types.uint(CoreModel.ACTIVATION_DELAY + 1),
+          startHeight: types.uint(activationBlock.height + CoreModel.ACTIVATION_DELAY - 1),
           endHeight: types.uint(blockUpgrade.height - 1),
         };
         const expectedNewContractData = {
@@ -506,7 +510,7 @@ describe("[CityCoin Auth]", () => {
         const oldContract = core.address;
         const newContract = core2.address;
 
-        chain.mineBlock([
+        let activationBlock = chain.mineBlock([
           core.testInitializeCore(oldContract),
           core.testSetActivationThreshold(1),
           core.registerUser(sender),
@@ -557,7 +561,7 @@ describe("[CityCoin Auth]", () => {
 
         const expectedOldContractData = {
           state: types.uint(AuthModel.ContractState.STATE_INACTIVE),
-          startHeight: types.uint(CoreModel.ACTIVATION_DELAY + 1),
+          startHeight: types.uint(activationBlock.height + CoreModel.ACTIVATION_DELAY - 1),
           endHeight: types.uint(blockUpgrade.height - 1),
         };
         const expectedNewContractData = {

--- a/tests/base/auth/citycoin-auth-job-management.test.ts
+++ b/tests/base/auth/citycoin-auth-job-management.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it} from "../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach} from "../../../deps.ts";
 import { Accounts, Context } from "../../../src/context.ts";
 import { AuthModel } from "../../../models/base/auth.model.ts";
 import { CoreModel } from "../../../models/base/core.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   auth = ctx.models.get(AuthModel);
   core = ctx.models.get(CoreModel, "citycoin-core-v1");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[CityCoin Auth]", () => {
   //////////////////////////////////////////////////

--- a/tests/base/auth/citycoin-auth-token-management.test.ts
+++ b/tests/base/auth/citycoin-auth-token-management.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, beforeEach, it} from "../../../deps.ts";
+import { describe, run, Chain, beforeEach, it, afterEach} from "../../../deps.ts";
 import { Accounts, Context } from "../../../src/context.ts";
 import { AuthModel } from "../../../models/base/auth.model.ts";
 import { TokenModel } from "../../../models/base/token.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   auth = ctx.models.get(AuthModel);
   token = ctx.models.get(TokenModel);
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[CityCoin Auth]", () => {
   //////////////////////////////////////////////////

--- a/tests/base/core/citycoin-core-v1-city-wallet-management.test.ts
+++ b/tests/base/core/citycoin-core-v1-city-wallet-management.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, beforeEach, it } from "../../../deps.ts";
+import { describe, run, Chain, beforeEach, it, afterEach } from "../../../deps.ts";
 import { Accounts, Context } from "../../../src/context.ts";
 import { CoreModel } from "../../../models/base/core.model.ts";
 
@@ -12,6 +12,10 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   core = ctx.models.get(CoreModel);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[CityCoin Core]", () => {

--- a/tests/base/core/citycoin-core-v1-mining-claims.test.ts
+++ b/tests/base/core/citycoin-core-v1-mining-claims.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, run, Chain, beforeEach, it } from "../../../deps.ts";
+import { assertEquals, describe, run, Chain, beforeEach, it, afterEach } from "../../../deps.ts";
 import { Accounts, Context } from "../../../src/context.ts";
 import { CoreModel } from "../../../models/base/core.model.ts";
 
@@ -12,6 +12,10 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   core = ctx.models.get(CoreModel);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[CityCoin Core]", () => {

--- a/tests/base/core/citycoin-core-v1-mining.test.ts
+++ b/tests/base/core/citycoin-core-v1-mining.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it } from "../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach } from "../../../deps.ts";
 import { Accounts, Context } from "../../../src/context.ts";
 import { CoreModel } from "../../../models/base/core.model.ts";
 import { TokenModel } from "../../../models/base/token.model.ts";
@@ -15,6 +15,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   core = ctx.models.get(CoreModel);
   token = ctx.models.get(TokenModel);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[CityCoin Core]", () => {

--- a/tests/base/core/citycoin-core-v1-registration.test.ts
+++ b/tests/base/core/citycoin-core-v1-registration.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it } from "../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach } from "../../../deps.ts";
 import { Accounts, Context } from "../../../src/context.ts";
 import { CoreModel } from "../../../models/base/core.model.ts";
 
@@ -12,6 +12,10 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   core = ctx.models.get(CoreModel);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[CityCoin Core]", () => {

--- a/tests/base/core/citycoin-core-v1-stacking-claims.test.ts
+++ b/tests/base/core/citycoin-core-v1-stacking-claims.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, run, Chain, beforeEach, it } from "../../../deps.ts";
+import { assertEquals, describe, run, Chain, beforeEach, it, afterEach } from "../../../deps.ts";
 import { Accounts, Context } from "../../../src/context.ts";
 import { CoreModel } from "../../../models/base/core.model.ts";
 import { TokenModel } from "../../../models/base/token.model.ts";
@@ -15,6 +15,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   core = ctx.models.get(CoreModel);
   token = ctx.models.get(TokenModel);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[CityCoin Core]", () => {

--- a/tests/base/core/citycoin-core-v1-stacking.test.ts
+++ b/tests/base/core/citycoin-core-v1-stacking.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, TxReceipt, types, run, Chain, beforeEach, it } from "../../../deps.ts";
+import { assertEquals, describe, TxReceipt, types, run, Chain, beforeEach, it, afterEach } from "../../../deps.ts";
 import { Accounts, Context } from "../../../src/context.ts";
 import { CoreModel } from "../../../models/base/core.model.ts";
 import { TokenModel } from "../../../models/base/token.model.ts";
@@ -15,6 +15,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   core = ctx.models.get(CoreModel);
   token = ctx.models.get(TokenModel);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[CityCoin Core]", () => {

--- a/tests/base/core/citycoin-core-v1-token-configuration.test.ts
+++ b/tests/base/core/citycoin-core-v1-token-configuration.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it } from "../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach } from "../../../deps.ts";
 import { Accounts, Context } from "../../../src/context.ts";
 import { CoreModel } from "../../../models/base/core.model.ts";
 
@@ -12,6 +12,10 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   core = ctx.models.get(CoreModel);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[CityCoin Core]", () => {

--- a/tests/base/token/citycoin-token-send-many.test.ts
+++ b/tests/base/token/citycoin-token-send-many.test.ts
@@ -1,4 +1,4 @@
-import { describe, assertEquals, types, Account, run, Chain, it, beforeEach} from "../../../deps.ts";
+import { describe, assertEquals, types, Account, run, Chain, it, beforeEach, afterEach} from "../../../deps.ts";
 import { Accounts, Context } from "../../../src/context.ts";
 import { TokenModel, SendManyRecord } from "../../../models/base/token.model.ts";
 
@@ -13,6 +13,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   token = ctx.models.get(TokenModel);
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[CityCoin Token]", () => {
   //////////////////////////////////////////////////

--- a/tests/base/token/citycoin-token-sip-010.test.ts
+++ b/tests/base/token/citycoin-token-sip-010.test.ts
@@ -1,4 +1,4 @@
-import { describe, assertEquals, types, run, Chain, it, beforeEach} from "../../../deps.ts";
+import { describe, assertEquals, types, run, Chain, it, beforeEach, afterEach} from "../../../deps.ts";
 import { Accounts, Context } from "../../../src/context.ts";
 import { TokenModel } from "../../../models/base/token.model.ts";
 
@@ -13,6 +13,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   token = ctx.models.get(TokenModel);
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[CityCoin Token]", () => {
   //////////////////////////////////////////////////

--- a/tests/base/token/citycoin-token-utilities.test.ts
+++ b/tests/base/token/citycoin-token-utilities.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, it, beforeEach} from "../../../deps.ts";
+import { describe, run, Chain, it, beforeEach, afterEach} from "../../../deps.ts";
 import { Accounts, Context } from "../../../src/context.ts";
 import { CoreModel } from "../../../models/base/core.model.ts";
 import { TokenModel } from "../../../models/base/token.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   token = ctx.models.get(TokenModel);
   core = ctx.models.get(CoreModel);
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[CityCoin Token]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/mia/auth/auth-v1/miamicoin-auth-city-wallet-management.test.ts
+++ b/tests/cities/mia/auth/auth-v1/miamicoin-auth-city-wallet-management.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, beforeEach, it} from "../../../../../deps.ts";
+import { describe, run, Chain, beforeEach, it, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinAuthModel } from "../../../../../models/cities/mia/miamicoin-auth.model.ts";
 import { MiamiCoinCoreModel } from "../../../../../models/cities/mia/miamicoin-core.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   auth = ctx.models.get(MiamiCoinAuthModel, "miamicoin-auth");
   core = ctx.models.get(MiamiCoinCoreModel, "miamicoin-core-v1");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[MiamiCoin Auth]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/mia/auth/auth-v1/miamicoin-auth-contract-management.test.ts
+++ b/tests/cities/mia/auth/auth-v1/miamicoin-auth-contract-management.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it} from "../../../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinAuthModel } from "../../../../../models/cities/mia/miamicoin-auth.model.ts";
 import { MiamiCoinCoreModel } from "../../../../../models/cities/mia/miamicoin-core.model.ts";
@@ -20,6 +20,10 @@ beforeEach(() => {
   core2 = ctx.models.get(MiamiCoinCoreModel, "miamicoin-core-v1-1");
   core3 = ctx.models.get(MiamiCoinCoreModel, "miamicoin-core-v1-2");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[MiamiCoin Auth]", () => {
   //////////////////////////////////////////////////
@@ -180,7 +184,7 @@ describe("[MiamiCoin Auth]", () => {
         const oldContract = core.address;
         const newContract = core2.address;
 
-        chain.mineBlock([
+        let activationBlock = chain.mineBlock([
           core.testInitializeCore(oldContract),
           core.testSetActivationThreshold(1),
           core.registerUser(sender),
@@ -205,7 +209,7 @@ describe("[MiamiCoin Auth]", () => {
 
         const expectedOldContractData = {
           state: types.uint(MiamiCoinAuthModel.CoreContractState.STATE_INACTIVE),
-          startHeight: types.uint(MiamiCoinCoreModel.ACTIVATION_DELAY + 1),
+          startHeight: types.uint(activationBlock.height + MiamiCoinCoreModel.ACTIVATION_DELAY - 1),
           endHeight: types.uint(blockUpgrade.height - 1),
         };
         const expectedNewContractData = {
@@ -392,7 +396,7 @@ describe("[MiamiCoin Auth]", () => {
         const oldContract = core.address;
         const newContract = core2.address;
 
-        chain.mineBlock([
+        let activationBlock = chain.mineBlock([
           core.testInitializeCore(oldContract),
           core.testSetActivationThreshold(1),
           core.registerUser(sender),
@@ -443,7 +447,7 @@ describe("[MiamiCoin Auth]", () => {
 
         const expectedOldContractData = {
           state: types.uint(MiamiCoinAuthModel.CoreContractState.STATE_INACTIVE),
-          startHeight: types.uint(MiamiCoinCoreModel.ACTIVATION_DELAY + 1),
+          startHeight: types.uint(activationBlock.height + MiamiCoinCoreModel.ACTIVATION_DELAY - 1),
           endHeight: types.uint(blockUpgrade.height - 1),
         };
         const expectedNewContractData = {

--- a/tests/cities/mia/auth/auth-v1/miamicoin-auth-job-management.test.ts
+++ b/tests/cities/mia/auth/auth-v1/miamicoin-auth-job-management.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it} from "../../../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinAuthModel } from "../../../../../models/cities/mia/miamicoin-auth.model.ts";
 import { MiamiCoinCoreModel } from "../../../../../models/cities/mia/miamicoin-core.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   auth = ctx.models.get(MiamiCoinAuthModel, "miamicoin-auth");
   core = ctx.models.get(MiamiCoinCoreModel, "miamicoin-core-v1");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[MiamiCoin Auth]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/mia/auth/auth-v1/miamicoin-auth-token-management.test.ts
+++ b/tests/cities/mia/auth/auth-v1/miamicoin-auth-token-management.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, beforeEach, it} from "../../../../../deps.ts";
+import { describe, run, Chain, beforeEach, it, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinAuthModel } from "../../../../../models/cities/mia/miamicoin-auth.model.ts";
 import { MiamiCoinTokenModel } from "../../../../../models/cities/mia/miamicoin-token.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   auth = ctx.models.get(MiamiCoinAuthModel, "miamicoin-auth");
   token = ctx.models.get(MiamiCoinTokenModel, "miamicoin-token");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[MiamiCoin Auth]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/mia/auth/auth-v2/miamicoin-auth-v2-city-wallet-management.test.ts
+++ b/tests/cities/mia/auth/auth-v2/miamicoin-auth-v2-city-wallet-management.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, beforeEach, it} from "../../../../../deps.ts";
+import { describe, run, Chain, beforeEach, it, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinAuthModelV2 } from "../../../../../models/cities/mia/miamicoin-auth-v2.model.ts";
 import { MiamiCoinCoreModelV2 } from "../../../../../models/cities/mia/miamicoin-core-v2.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   authV2 = ctx.models.get(MiamiCoinAuthModelV2, "miamicoin-auth-v2");
   coreV2 = ctx.models.get(MiamiCoinCoreModelV2, "miamicoin-core-v2");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[MiamiCoin Auth v2]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/mia/auth/auth-v2/miamicoin-auth-v2-contract-management.test.ts
+++ b/tests/cities/mia/auth/auth-v2/miamicoin-auth-v2-contract-management.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it} from "../../../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinAuthModelV2 } from "../../../../../models/cities/mia/miamicoin-auth-v2.model.ts";
 import { MiamiCoinCoreModelV2 } from "../../../../../models/cities/mia/miamicoin-core-v2.model.ts";
@@ -20,6 +20,10 @@ beforeEach(() => {
   coreV2_2 = ctx.models.get(MiamiCoinCoreModelV2, "miamicoin-core-v2-1");
   coreV2_3 = ctx.models.get(MiamiCoinCoreModelV2, "miamicoin-core-v2-2");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[MiamiCoin Auth v2]", () => {
   //////////////////////////////////////////////////
@@ -203,7 +207,7 @@ describe("[MiamiCoin Auth v2]", () => {
         const oldContract = coreV2.address;
         const newContract = coreV2_2.address;
 
-        chain.mineBlock([
+        let activationBlock = chain.mineBlock([
           coreV2.testInitializeCore(oldContract),
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(sender),
@@ -228,7 +232,7 @@ describe("[MiamiCoin Auth v2]", () => {
 
         const expectedOldContractData = {
           state: types.uint(MiamiCoinAuthModelV2.CoreContractState.STATE_INACTIVE),
-          startHeight: types.uint(MiamiCoinCoreModelV2.ACTIVATION_DELAY + 1),
+          startHeight: types.uint(activationBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1),
           endHeight: types.uint(blockUpgrade.height - 1),
         };
         const expectedNewContractData = {
@@ -451,7 +455,7 @@ describe("[MiamiCoin Auth v2]", () => {
         const oldContract = coreV2.address;
         const newContract = coreV2_2.address;
 
-        chain.mineBlock([
+        let activationBlock = chain.mineBlock([
           coreV2.testInitializeCore(oldContract),
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(sender),
@@ -502,7 +506,7 @@ describe("[MiamiCoin Auth v2]", () => {
 
         const expectedOldContractData = {
           state: types.uint(MiamiCoinAuthModelV2.CoreContractState.STATE_INACTIVE),
-          startHeight: types.uint(MiamiCoinCoreModelV2.ACTIVATION_DELAY + 1),
+          startHeight: types.uint(activationBlock.height + MiamiCoinCoreModelV2.ACTIVATION_DELAY - 1),
           endHeight: types.uint(blockUpgrade.height - 1),
         };
         const expectedNewContractData = {

--- a/tests/cities/mia/auth/auth-v2/miamicoin-auth-v2-job-management.test.ts
+++ b/tests/cities/mia/auth/auth-v2/miamicoin-auth-v2-job-management.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it} from "../../../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinAuthModelV2 } from "../../../../../models/cities/mia/miamicoin-auth-v2.model.ts";
 import { MiamiCoinCoreModelV2 } from "../../../../../models/cities/mia/miamicoin-core-v2.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   authV2 = ctx.models.get(MiamiCoinAuthModelV2, "miamicoin-auth-v2");
   coreV2 = ctx.models.get(MiamiCoinCoreModelV2, "miamicoin-core-v2");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[MiamiCoin Auth v2]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/mia/auth/auth-v2/miamicoin-auth-v2-token-management.test.ts
+++ b/tests/cities/mia/auth/auth-v2/miamicoin-auth-v2-token-management.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, beforeEach, it, assertEquals, types} from "../../../../../deps.ts";
+import { describe, run, Chain, beforeEach, it, assertEquals, types, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinAuthModelV2 } from "../../../../../models/cities/mia/miamicoin-auth-v2.model.ts";
 import { MiamiCoinCoreModelV2 } from "../../../../../models/cities/mia/miamicoin-core-v2.model.ts";
@@ -21,6 +21,10 @@ beforeEach(() => {
   coreV2_2 = ctx.models.get(MiamiCoinCoreModelV2, "miamicoin-core-v2-2");
   tokenV2 = ctx.models.get(MiamiCoinTokenModelV2, "miamicoin-token-v2");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[MiamiCoin Auth v2]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/mia/core/core-v1-patch/miamicoin-core-v1-patch.test.ts
+++ b/tests/cities/mia/core/core-v1-patch/miamicoin-core-v1-patch.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, run, Chain, beforeEach, it, Account } from "../../../../../deps.ts";
+import { assertEquals, describe, run, Chain, beforeEach, it, Account, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinAuthModel } from "../../../../../models/cities/mia/miamicoin-auth.model.ts";
 import { MiamiCoinCoreModel } from "../../../../../models/cities/mia/miamicoin-core.model.ts";
@@ -21,6 +21,10 @@ beforeEach(() => {
   core = ctx.models.get(MiamiCoinCoreModel, "miamicoin-core-v1");
   coreV1Patch = ctx.models.get(MiamiCoinCoreModelPatch, "miamicoin-core-v1-patch");
   token = ctx.models.get(MiamiCoinTokenModel, "miamicoin-token");
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[MiamiCoin Core v1 Patch]", () => {

--- a/tests/cities/mia/core/core-v1/miamicoin-core-v1-city-wallet-management.test.ts
+++ b/tests/cities/mia/core/core-v1/miamicoin-core-v1-city-wallet-management.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { describe, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinCoreModel } from "../../../../../models/cities/mia/miamicoin-core.model.ts";
 
@@ -12,6 +12,10 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   core = ctx.models.get(MiamiCoinCoreModel, "miamicoin-core-v1");
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[MiamiCoin Core]", () => {

--- a/tests/cities/mia/core/core-v1/miamicoin-core-v1-mining-claims.test.ts
+++ b/tests/cities/mia/core/core-v1/miamicoin-core-v1-mining-claims.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinCoreModel } from "../../../../../models/cities/mia/miamicoin-core.model.ts";
 
@@ -12,6 +12,10 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   core = ctx.models.get(MiamiCoinCoreModel, "miamicoin-core-v1");
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[MiamiCoin Core]", () => {

--- a/tests/cities/mia/core/core-v1/miamicoin-core-v1-mining.test.ts
+++ b/tests/cities/mia/core/core-v1/miamicoin-core-v1-mining.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinCoreModel } from "../../../../../models/cities/mia/miamicoin-core.model.ts";
 import { MiamiCoinTokenModel } from "../../../../../models/cities/mia/miamicoin-token.model.ts";
@@ -15,6 +15,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   core = ctx.models.get(MiamiCoinCoreModel, "miamicoin-core-v1");
   token = ctx.models.get(MiamiCoinTokenModel, "miamicoin-token");
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[MiamiCoin Core]", () => {

--- a/tests/cities/mia/core/core-v1/miamicoin-core-v1-registration.test.ts
+++ b/tests/cities/mia/core/core-v1/miamicoin-core-v1-registration.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinCoreModel } from "../../../../../models/cities/mia/miamicoin-core.model.ts";
 
@@ -12,6 +12,10 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   core = ctx.models.get(MiamiCoinCoreModel, "miamicoin-core-v1");
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[MiamiCoin Core]", () => {

--- a/tests/cities/mia/core/core-v1/miamicoin-core-v1-stacking-claims.test.ts
+++ b/tests/cities/mia/core/core-v1/miamicoin-core-v1-stacking-claims.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinCoreModel } from "../../../../../models/cities/mia/miamicoin-core.model.ts";
 import { MiamiCoinTokenModel } from "../../../../../models/cities/mia/miamicoin-token.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   core = ctx.models.get(MiamiCoinCoreModel, "miamicoin-core-v1");
   token = ctx.models.get(MiamiCoinTokenModel, "miamicoin-token");
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[MiamiCoin Core]", () => {

--- a/tests/cities/mia/core/core-v1/miamicoin-core-v1-stacking.test.ts
+++ b/tests/cities/mia/core/core-v1/miamicoin-core-v1-stacking.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, TxReceipt, types, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, TxReceipt, types, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinCoreModel } from "../../../../../models/cities/mia/miamicoin-core.model.ts";
 import { MiamiCoinTokenModel } from "../../../../../models/cities/mia/miamicoin-token.model.ts";
@@ -15,6 +15,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   core = ctx.models.get(MiamiCoinCoreModel, "miamicoin-core-v1");
   token = ctx.models.get(MiamiCoinTokenModel, "miamicoin-token");
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[MiamiCoin Core]", () => {

--- a/tests/cities/mia/core/core-v1/miamicoin-core-v1-token-configuration.test.ts
+++ b/tests/cities/mia/core/core-v1/miamicoin-core-v1-token-configuration.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinCoreModel } from "../../../../../models/cities/mia/miamicoin-core.model.ts";
 
@@ -12,6 +12,10 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   core = ctx.models.get(MiamiCoinCoreModel, "miamicoin-core-v1");
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[MiamiCoin Core]", () => {

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-city-wallet-management.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-city-wallet-management.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { describe, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinCoreModelV2 } from "../../../../../models/cities/mia/miamicoin-core-v2.model.ts";
 
@@ -13,6 +13,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   coreV2 = ctx.models.get(MiamiCoinCoreModelV2, "miamicoin-core-v2");
   chain.mineEmptyBlock(59000);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[MiamiCoin Core v2]", () => {

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-mining-claims.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-mining-claims.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinCoreModelV2 } from "../../../../../models/cities/mia/miamicoin-core-v2.model.ts";
 
@@ -13,6 +13,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   coreV2 = ctx.models.get(MiamiCoinCoreModelV2, "miamicoin-core-v2");
   chain.mineEmptyBlock(59000);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[MiamiCoin Core v2]", () => {

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-mining.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-mining.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinCoreModelV2 } from "../../../../../models/cities/mia/miamicoin-core-v2.model.ts";
 import { MiamiCoinTokenModelV2 } from "../../../../../models/cities/mia/miamicoin-token-v2.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   coreV2 = ctx.models.get(MiamiCoinCoreModelV2, "miamicoin-core-v2");
   tokenV2 = ctx.models.get(MiamiCoinTokenModelV2, "miamicoin-token-v2");
   chain.mineEmptyBlock(59000);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[MiamiCoin Core v2]", () => {

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-registration.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-registration.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinCoreModelV2 } from "../../../../../models/cities/mia/miamicoin-core-v2.model.ts";
 
@@ -13,6 +13,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   coreV2 = ctx.models.get(MiamiCoinCoreModelV2, "miamicoin-core-v2");
   chain.mineEmptyBlock(59000);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[MiamiCoin Core v2]", () => {

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-stacking-claims.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-stacking-claims.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinCoreModelV2 } from "../../../../../models/cities/mia/miamicoin-core-v2.model.ts";
 import { MiamiCoinTokenModelV2 } from "../../../../../models/cities/mia/miamicoin-token-v2.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   coreV2 = ctx.models.get(MiamiCoinCoreModelV2, "miamicoin-core-v2");
   tokenV2 = ctx.models.get(MiamiCoinTokenModelV2, "miamicoin-token-v2");
   chain.mineEmptyBlock(59000);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[MiamiCoin Core v2]", () => {

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-stacking.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-stacking.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, TxReceipt, types, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, TxReceipt, types, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinCoreModelV2 } from "../../../../../models/cities/mia/miamicoin-core-v2.model.ts";
 import { MiamiCoinTokenModelV2 } from "../../../../../models/cities/mia/miamicoin-token-v2.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   coreV2 = ctx.models.get(MiamiCoinCoreModelV2, "miamicoin-core-v2");
   tokenV2 = ctx.models.get(MiamiCoinTokenModelV2, "miamicoin-token-v2");
   chain.mineEmptyBlock(59000);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[MiamiCoin Core v2]", () => {

--- a/tests/cities/mia/core/core-v2/miamicoin-core-v2-token-configuration.test.ts
+++ b/tests/cities/mia/core/core-v2/miamicoin-core-v2-token-configuration.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinCoreModelV2 } from "../../../../../models/cities/mia/miamicoin-core-v2.model.ts";
 
@@ -13,6 +13,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   coreV2 = ctx.models.get(MiamiCoinCoreModelV2, "miamicoin-core-v2");
   chain.mineEmptyBlock(59000);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[MiamiCoin Core v2]", () => {

--- a/tests/cities/mia/token/token-v1/miamicoin-token-send-many.test.ts
+++ b/tests/cities/mia/token/token-v1/miamicoin-token-send-many.test.ts
@@ -1,4 +1,4 @@
-import { describe, assertEquals, types, Account, run, Chain, it, beforeEach} from "../../../../../deps.ts";
+import { describe, assertEquals, types, Account, run, Chain, it, beforeEach, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinTokenModel, SendManyRecord } from "../../../../../models/cities/mia/miamicoin-token.model.ts";
 
@@ -13,6 +13,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   token = ctx.models.get(MiamiCoinTokenModel, "miamicoin-token");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[MiamiCoin Token]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/mia/token/token-v1/miamicoin-token-sip-010.test.ts
+++ b/tests/cities/mia/token/token-v1/miamicoin-token-sip-010.test.ts
@@ -1,4 +1,4 @@
-import { describe, assertEquals, types, run, Chain, it, beforeEach} from "../../../../../deps.ts";
+import { describe, assertEquals, types, run, Chain, it, beforeEach, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinCoreModel } from "../../../../../models/cities/mia/miamicoin-core.model.ts";
 import { MiamiCoinTokenModel } from "../../../../../models/cities/mia/miamicoin-token.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   core = ctx.models.get(MiamiCoinCoreModel, "miamicoin-core-v1")
   token = ctx.models.get(MiamiCoinTokenModel, "miamicoin-token");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[MiamiCoin Token]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/mia/token/token-v1/miamicoin-token-utilities.test.ts
+++ b/tests/cities/mia/token/token-v1/miamicoin-token-utilities.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, it, beforeEach} from "../../../../../deps.ts";
+import { describe, run, Chain, it, beforeEach, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinCoreModel } from "../../../../../models/cities/mia/miamicoin-core.model.ts";
 import { MiamiCoinTokenModel } from "../../../../../models/cities/mia/miamicoin-token.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   core = ctx.models.get(MiamiCoinCoreModel, "miamicoin-core-v1");
   token = ctx.models.get(MiamiCoinTokenModel, "miamicoin-token");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[MiamiCoin Token]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/mia/token/token-v2/miamicoin-token-v2-send-many.test.ts
+++ b/tests/cities/mia/token/token-v2/miamicoin-token-v2-send-many.test.ts
@@ -1,4 +1,4 @@
-import { describe, assertEquals, types, Account, run, Chain, it, beforeEach} from "../../../../../deps.ts";
+import { describe, assertEquals, types, Account, run, Chain, it, beforeEach, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinTokenModelV2, SendManyRecord  } from "../../../../../models/cities/mia/miamicoin-token-v2.model.ts";
 
@@ -13,6 +13,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   tokenV2 = ctx.models.get(MiamiCoinTokenModelV2, "miamicoin-token-v2");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[MiamiCoin Token v2]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/mia/token/token-v2/miamicoin-token-v2-sip-010.test.ts
+++ b/tests/cities/mia/token/token-v2/miamicoin-token-v2-sip-010.test.ts
@@ -1,4 +1,4 @@
-import { describe, assertEquals, types, run, Chain, it, beforeEach} from "../../../../../deps.ts";
+import { describe, assertEquals, types, run, Chain, it, beforeEach, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinTokenModelV2 } from "../../../../../models/cities/mia/miamicoin-token-v2.model.ts";
 
@@ -13,6 +13,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   tokenV2 = ctx.models.get(MiamiCoinTokenModelV2, "miamicoin-token-v2");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[MiamiCoin Token v2]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/mia/token/token-v2/miamicoin-token-v2-utilities.test.ts
+++ b/tests/cities/mia/token/token-v2/miamicoin-token-v2-utilities.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, it, beforeEach, types, assertEquals} from "../../../../../deps.ts";
+import { describe, run, Chain, it, beforeEach, types, assertEquals, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { MiamiCoinAuthModel } from "../../../../../models/cities/mia/miamicoin-auth.model.ts";
 import { MiamiCoinCoreModel } from "../../../../../models/cities/mia/miamicoin-core.model.ts";
@@ -28,6 +28,10 @@ beforeEach(() => {
   token = ctx.models.get(MiamiCoinTokenModel, "miamicoin-token");
   tokenV2 = ctx.models.get(MiamiCoinTokenModelV2, "miamicoin-token-v2");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[MiamiCoin Token v2]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/mia/upgrade/miamicoin-core-v1-v2.test.ts
+++ b/tests/cities/mia/upgrade/miamicoin-core-v1-v2.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, run, Chain, beforeEach, it, Account, types } from "../../../../deps.ts";
+import { assertEquals, describe, run, Chain, beforeEach, it, Account, types, afterEach, Block } from "../../../../deps.ts";
 import { Accounts, Context } from "../../../../src/context.ts";
 import { MiamiCoinAuthModel } from "../../../../models/cities/mia/miamicoin-auth.model.ts";
 import { MiamiCoinCoreModel } from "../../../../models/cities/mia/miamicoin-core.model.ts";
@@ -29,6 +29,10 @@ beforeEach(() => {
   tokenV2 = ctx.models.get(MiamiCoinTokenModelV2, "miamicoin-token-v2");
 });
 
+afterEach(() => {
+  ctx.terminate()
+});
+
 describe("[MiamiCoin Upgrade v1-v2]", () => {
   const jobId = 1;
   const minerCommit = 10;
@@ -42,6 +46,9 @@ describe("[MiamiCoin Upgrade v1-v2]", () => {
   let user2: Account;
   let user3: Account;
   let cityWallet: Account;
+  let block1: Block;
+  let block2: Block;
+  let block3: Block;
 
   beforeEach(() => {
     // setup accounts
@@ -69,21 +76,21 @@ describe("[MiamiCoin Upgrade v1-v2]", () => {
 
     // mine tokens for claim in past
     // block: 24646, user1
-    chain.mineBlock([
+    block1 = chain.mineBlock([
       core.mineTokens(minerCommit * 1000, user1),
       core.mineTokens(minerCommit, user2),
       core.mineTokens(minerCommit, user3),
     ]);
     chain.mineEmptyBlock(100);
     // block: 24747, user2
-    chain.mineBlock([
+    block2 = chain.mineBlock([
       core.mineTokens(minerCommit, user1),
       core.mineTokens(minerCommit * 1000, user2),
       core.mineTokens(minerCommit, user3),
     ]);
     chain.mineEmptyBlock(100);
     // block: 24848, user3
-    chain.mineBlock([
+    block3 = chain.mineBlock([
       core.mineTokens(minerCommit, user1),
       core.mineTokens(minerCommit, user2),
       core.mineTokens(minerCommit * 1000, user3),
@@ -356,9 +363,9 @@ describe("[MiamiCoin Upgrade v1-v2]", () => {
 
   it("claim-mining-reward() succeeds in v1 with block height in the past", () => {
     // arrange
-    const targetBlock1 = 24646;
-    const targetBlock2 = 24747;
-    const targetBlock3 = 24848;
+    const targetBlock1 = block1.height - 1;
+    const targetBlock2 = block2.height - 1;
+    const targetBlock3 = block3.height - 1;
     // act
     const block = chain.mineBlock([
       core.claimMiningReward(targetBlock1, user1),

--- a/tests/cities/nyc/auth/auth-v1/newyorkcitycoin-auth-city-wallet-management.test.ts
+++ b/tests/cities/nyc/auth/auth-v1/newyorkcitycoin-auth-city-wallet-management.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, beforeEach, it} from "../../../../../deps.ts";
+import { describe, run, Chain, beforeEach, it, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinAuthModel } from "../../../../../models/cities/nyc/newyorkcitycoin-auth.model.ts";
 import { NewYorkCityCoinCoreModel } from "../../../../../models/cities/nyc/newyorkcitycoin-core.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   auth = ctx.models.get(NewYorkCityCoinAuthModel, "newyorkcitycoin-auth");
   core = ctx.models.get(NewYorkCityCoinCoreModel, "newyorkcitycoin-core-v1");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[NewYorkCityCoin Auth]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/nyc/auth/auth-v1/newyorkcitycoin-auth-contract-management.test.ts
+++ b/tests/cities/nyc/auth/auth-v1/newyorkcitycoin-auth-contract-management.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it} from "../../../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinAuthModel } from "../../../../../models/cities/nyc/newyorkcitycoin-auth.model.ts";
 import { NewYorkCityCoinCoreModel } from "../../../../../models/cities/nyc/newyorkcitycoin-core.model.ts";
@@ -20,6 +20,10 @@ beforeEach(() => {
   core2 = ctx.models.get(NewYorkCityCoinCoreModel, "newyorkcitycoin-core-v1-1");
   core3 = ctx.models.get(NewYorkCityCoinCoreModel, "newyorkcitycoin-core-v1-2");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[NewYorkCityCoin Auth]", () => {
   //////////////////////////////////////////////////
@@ -180,7 +184,7 @@ describe("[NewYorkCityCoin Auth]", () => {
         const oldContract = core.address;
         const newContract = core2.address;
 
-        chain.mineBlock([
+        let activationBlock = chain.mineBlock([
           core.testInitializeCore(oldContract),
           core.testSetActivationThreshold(1),
           core.registerUser(sender),
@@ -205,7 +209,7 @@ describe("[NewYorkCityCoin Auth]", () => {
 
         const expectedOldContractData = {
           state: types.uint(NewYorkCityCoinAuthModel.CoreContractState.STATE_INACTIVE),
-          startHeight: types.uint(NewYorkCityCoinCoreModel.ACTIVATION_DELAY + 1),
+          startHeight: types.uint(activationBlock.height + NewYorkCityCoinCoreModel.ACTIVATION_DELAY - 1),
           endHeight: types.uint(blockUpgrade.height - 1),
         };
         const expectedNewContractData = {
@@ -392,7 +396,7 @@ describe("[NewYorkCityCoin Auth]", () => {
         const oldContract = core.address;
         const newContract = core2.address;
 
-        chain.mineBlock([
+        let activationBlock = chain.mineBlock([
           core.testInitializeCore(oldContract),
           core.testSetActivationThreshold(1),
           core.registerUser(sender),
@@ -443,7 +447,7 @@ describe("[NewYorkCityCoin Auth]", () => {
 
         const expectedOldContractData = {
           state: types.uint(NewYorkCityCoinAuthModel.CoreContractState.STATE_INACTIVE),
-          startHeight: types.uint(NewYorkCityCoinCoreModel.ACTIVATION_DELAY + 1),
+          startHeight: types.uint(activationBlock.height + NewYorkCityCoinCoreModel.ACTIVATION_DELAY - 1),
           endHeight: types.uint(blockUpgrade.height - 1),
         };
         const expectedNewContractData = {

--- a/tests/cities/nyc/auth/auth-v1/newyorkcitycoin-auth-job-management.test.ts
+++ b/tests/cities/nyc/auth/auth-v1/newyorkcitycoin-auth-job-management.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it} from "../../../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinAuthModel } from "../../../../../models/cities/nyc/newyorkcitycoin-auth.model.ts";
 import { NewYorkCityCoinCoreModel } from "../../../../../models/cities/nyc/newyorkcitycoin-core.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   auth = ctx.models.get(NewYorkCityCoinAuthModel, "newyorkcitycoin-auth");
   core = ctx.models.get(NewYorkCityCoinCoreModel, "newyorkcitycoin-core-v1");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[NewYorkCityCoin Auth]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/nyc/auth/auth-v1/newyorkcitycoin-auth-token-management.test.ts
+++ b/tests/cities/nyc/auth/auth-v1/newyorkcitycoin-auth-token-management.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, beforeEach, it} from "../../../../../deps.ts";
+import { describe, run, Chain, beforeEach, it, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinAuthModel } from "../../../../../models/cities/nyc/newyorkcitycoin-auth.model.ts";
 import { NewYorkCityCoinTokenModel } from "../../../../../models/cities/nyc/newyorkcitycoin-token.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   auth = ctx.models.get(NewYorkCityCoinAuthModel, "newyorkcitycoin-auth");
   token = ctx.models.get(NewYorkCityCoinTokenModel, "newyorkcitycoin-token");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[NewYorkCityCoin Auth]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/nyc/auth/auth-v2/newyorkcitycoin-auth-v2-city-wallet-management.test.ts
+++ b/tests/cities/nyc/auth/auth-v2/newyorkcitycoin-auth-v2-city-wallet-management.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, beforeEach, it} from "../../../../../deps.ts";
+import { describe, run, Chain, beforeEach, it, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinAuthModelV2 } from "../../../../../models/cities/nyc/newyorkcitycoin-auth-v2.model.ts";
 import { NewYorkCityCoinCoreModelV2 } from "../../../../../models/cities/nyc/newyorkcitycoin-core-v2.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   authV2 = ctx.models.get(NewYorkCityCoinAuthModelV2, "newyorkcitycoin-auth-v2");
   coreV2 = ctx.models.get(NewYorkCityCoinCoreModelV2, "newyorkcitycoin-core-v2");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[NewYorkCityCoin Auth v2]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/nyc/auth/auth-v2/newyorkcitycoin-auth-v2-contract-management.test.ts
+++ b/tests/cities/nyc/auth/auth-v2/newyorkcitycoin-auth-v2-contract-management.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it} from "../../../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinAuthModelV2 } from "../../../../../models/cities/nyc/newyorkcitycoin-auth-v2.model.ts";
 import { NewYorkCityCoinCoreModelV2 } from "../../../../../models/cities/nyc/newyorkcitycoin-core-v2.model.ts";
@@ -20,6 +20,10 @@ beforeEach(() => {
   coreV2_2 = ctx.models.get(NewYorkCityCoinCoreModelV2, "newyorkcitycoin-core-v2-1");
   coreV2_3 = ctx.models.get(NewYorkCityCoinCoreModelV2, "newyorkcitycoin-core-v2-2");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[NewYorkCityCoin Auth v2]", () => {
   //////////////////////////////////////////////////
@@ -203,7 +207,7 @@ describe("[NewYorkCityCoin Auth v2]", () => {
         const oldContract = coreV2.address;
         const newContract = coreV2_2.address;
 
-        chain.mineBlock([
+        let activationBlock = chain.mineBlock([
           coreV2.testInitializeCore(oldContract),
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(sender),
@@ -228,7 +232,7 @@ describe("[NewYorkCityCoin Auth v2]", () => {
 
         const expectedOldContractData = {
           state: types.uint(NewYorkCityCoinAuthModelV2.CoreContractState.STATE_INACTIVE),
-          startHeight: types.uint(NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY + 1),
+          startHeight: types.uint(activationBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1),
           endHeight: types.uint(blockUpgrade.height - 1),
         };
         const expectedNewContractData = {
@@ -451,7 +455,7 @@ describe("[NewYorkCityCoin Auth v2]", () => {
         const oldContract = coreV2.address;
         const newContract = coreV2_2.address;
 
-        chain.mineBlock([
+        let activationBlock = chain.mineBlock([
           coreV2.testInitializeCore(oldContract),
           coreV2.testSetActivationThreshold(1),
           coreV2.registerUser(sender),
@@ -502,7 +506,7 @@ describe("[NewYorkCityCoin Auth v2]", () => {
 
         const expectedOldContractData = {
           state: types.uint(NewYorkCityCoinAuthModelV2.CoreContractState.STATE_INACTIVE),
-          startHeight: types.uint(NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY + 1),
+          startHeight: types.uint(activationBlock.height + NewYorkCityCoinCoreModelV2.ACTIVATION_DELAY - 1),
           endHeight: types.uint(blockUpgrade.height - 1),
         };
         const expectedNewContractData = {

--- a/tests/cities/nyc/auth/auth-v2/newyorkcitycoin-auth-v2-job-management.test.ts
+++ b/tests/cities/nyc/auth/auth-v2/newyorkcitycoin-auth-v2-job-management.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it} from "../../../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinAuthModelV2 } from "../../../../../models/cities/nyc/newyorkcitycoin-auth-v2.model.ts";
 import { NewYorkCityCoinCoreModelV2 } from "../../../../../models/cities/nyc/newyorkcitycoin-core-v2.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   authV2 = ctx.models.get(NewYorkCityCoinAuthModelV2, "newyorkcitycoin-auth-v2");
   coreV2 = ctx.models.get(NewYorkCityCoinCoreModelV2, "newyorkcitycoin-core-v2");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[NewYorkCityCoin Auth v2]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/nyc/auth/auth-v2/newyorkcitycoin-auth-v2-token-management.test.ts
+++ b/tests/cities/nyc/auth/auth-v2/newyorkcitycoin-auth-v2-token-management.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, beforeEach, it, assertEquals, types} from "../../../../../deps.ts";
+import { describe, run, Chain, beforeEach, it, assertEquals, types, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinAuthModelV2 } from "../../../../../models/cities/nyc/newyorkcitycoin-auth-v2.model.ts";
 import { NewYorkCityCoinCoreModelV2 } from "../../../../../models/cities/nyc/newyorkcitycoin-core-v2.model.ts";
@@ -21,6 +21,10 @@ beforeEach(() => {
   coreV2_2 = ctx.models.get(NewYorkCityCoinCoreModelV2, "newyorkcitycoin-core-v2-1");
   tokenV2 = ctx.models.get(NewYorkCityCoinTokenModelV2, "newyorkcitycoin-token-v2");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[NewYorkCityCoin Auth v2]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/nyc/core/core-v1-patch/newyorkcitycoin-core-v1-patch.test.ts
+++ b/tests/cities/nyc/core/core-v1-patch/newyorkcitycoin-core-v1-patch.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { describe, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinAuthModel } from "../../../../../models/cities/nyc/newyorkcitycoin-auth.model.ts";
 import { NewYorkCityCoinCoreModelPatch } from "../../../../../models/cities/nyc/newyorkcitycoin-core-v1-patch.model.ts";
@@ -15,6 +15,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   auth = ctx.models.get(NewYorkCityCoinAuthModel, "newyorkcitycoin-auth");
   coreV1Patch = ctx.models.get(NewYorkCityCoinCoreModelPatch, "newyorkcitycoin-core-v1-patch");
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[NewYorkCityCoin Core v1 Patch]", () => {

--- a/tests/cities/nyc/core/core-v1/newyorkcitycoin-core-v1-city-wallet-management.test.ts
+++ b/tests/cities/nyc/core/core-v1/newyorkcitycoin-core-v1-city-wallet-management.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { describe, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinCoreModel } from "../../../../../models/cities/nyc/newyorkcitycoin-core.model.ts";
 
@@ -12,6 +12,10 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   core = ctx.models.get(NewYorkCityCoinCoreModel, "newyorkcitycoin-core-v1");
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[NewYorkCityCoin Core]", () => {

--- a/tests/cities/nyc/core/core-v1/newyorkcitycoin-core-v1-mining-claims.test.ts
+++ b/tests/cities/nyc/core/core-v1/newyorkcitycoin-core-v1-mining-claims.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinCoreModel } from "../../../../../models/cities/nyc/newyorkcitycoin-core.model.ts";
 
@@ -12,6 +12,10 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   core = ctx.models.get(NewYorkCityCoinCoreModel, "newyorkcitycoin-core-v1");
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[NewYorkCityCoin Core]", () => {

--- a/tests/cities/nyc/core/core-v1/newyorkcitycoin-core-v1-mining.test.ts
+++ b/tests/cities/nyc/core/core-v1/newyorkcitycoin-core-v1-mining.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinCoreModel } from "../../../../../models/cities/nyc/newyorkcitycoin-core.model.ts";
 import { NewYorkCityCoinTokenModel } from "../../../../../models/cities/nyc/newyorkcitycoin-token.model.ts";
@@ -15,6 +15,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   core = ctx.models.get(NewYorkCityCoinCoreModel, "newyorkcitycoin-core-v1");
   token = ctx.models.get(NewYorkCityCoinTokenModel, "newyorkcitycoin-token");
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[NewYorkCityCoin Core]", () => {

--- a/tests/cities/nyc/core/core-v1/newyorkcitycoin-core-v1-registration.test.ts
+++ b/tests/cities/nyc/core/core-v1/newyorkcitycoin-core-v1-registration.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinCoreModel } from "../../../../../models/cities/nyc/newyorkcitycoin-core.model.ts";
 
@@ -12,6 +12,10 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   core = ctx.models.get(NewYorkCityCoinCoreModel);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[NewYorkCityCoin Core]", () => {

--- a/tests/cities/nyc/core/core-v1/newyorkcitycoin-core-v1-stacking-claims.test.ts
+++ b/tests/cities/nyc/core/core-v1/newyorkcitycoin-core-v1-stacking-claims.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinCoreModel } from "../../../../../models/cities/nyc/newyorkcitycoin-core.model.ts";
 import { NewYorkCityCoinTokenModel } from "../../../../../models/cities/nyc/newyorkcitycoin-token.model.ts";
@@ -15,6 +15,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   core = ctx.models.get(NewYorkCityCoinCoreModel, "newyorkcitycoin-core-v1");
   token = ctx.models.get(NewYorkCityCoinTokenModel, "newyorkcitycoin-token");
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[NewYorkCityCoin Core]", () => {

--- a/tests/cities/nyc/core/core-v1/newyorkcitycoin-core-v1-stacking.test.ts
+++ b/tests/cities/nyc/core/core-v1/newyorkcitycoin-core-v1-stacking.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, TxReceipt, types, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, TxReceipt, types, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinCoreModel } from "../../../../../models/cities/nyc/newyorkcitycoin-core.model.ts";
 import { NewYorkCityCoinTokenModel } from "../../../../../models/cities/nyc/newyorkcitycoin-token.model.ts";
@@ -15,6 +15,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   core = ctx.models.get(NewYorkCityCoinCoreModel, "newyorkcitycoin-core-v1");
   token = ctx.models.get(NewYorkCityCoinTokenModel, "newyorkcitycoin-token");
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[NewYorkCityCoin Core]", () => {

--- a/tests/cities/nyc/core/core-v1/newyorkcitycoin-core-v1-token-configuration.test.ts
+++ b/tests/cities/nyc/core/core-v1/newyorkcitycoin-core-v1-token-configuration.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinCoreModel } from "../../../../../models/cities/nyc/newyorkcitycoin-core.model.ts";
 
@@ -12,6 +12,10 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   core = ctx.models.get(NewYorkCityCoinCoreModel, "newyorkcitycoin-core-v1");
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[NewYorkCityCoin Core]", () => {

--- a/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-city-wallet-management.test.ts
+++ b/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-city-wallet-management.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { describe, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinCoreModelV2 } from "../../../../../models/cities/nyc/newyorkcitycoin-core-v2.model.ts";
 
@@ -13,6 +13,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   coreV2 = ctx.models.get(NewYorkCityCoinCoreModelV2, "newyorkcitycoin-core-v2");
   chain.mineEmptyBlock(59000);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[NewYorkCityCoin Core v2]", () => {

--- a/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-mining-claims.test.ts
+++ b/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-mining-claims.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinCoreModelV2 } from "../../../../../models/cities/nyc/newyorkcitycoin-core-v2.model.ts";
 
@@ -13,6 +13,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   coreV2 = ctx.models.get(NewYorkCityCoinCoreModelV2, "newyorkcitycoin-core-v2");
   chain.mineEmptyBlock(59000);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[NewYorkCityCoin Core v2]", () => {

--- a/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-mining.test.ts
+++ b/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-mining.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinCoreModelV2 } from "../../../../../models/cities/nyc/newyorkcitycoin-core-v2.model.ts";
 import { NewYorkCityCoinTokenModelV2 } from "../../../../../models/cities/nyc/newyorkcitycoin-token-v2.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   coreV2 = ctx.models.get(NewYorkCityCoinCoreModelV2, "newyorkcitycoin-core-v2");
   tokenV2 = ctx.models.get(NewYorkCityCoinTokenModelV2, "newyorkcitycoin-token-v2");
   chain.mineEmptyBlock(59000);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[NewYorkCityCoin Core v2]", () => {

--- a/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-registration.test.ts
+++ b/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-registration.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinCoreModelV2 } from "../../../../../models/cities/nyc/newyorkcitycoin-core-v2.model.ts";
 
@@ -13,6 +13,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   coreV2 = ctx.models.get(NewYorkCityCoinCoreModelV2, "newyorkcitycoin-core-v2");
   chain.mineEmptyBlock(59000);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[NewYorkCityCoin Core v2]", () => {

--- a/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-stacking-claims.test.ts
+++ b/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-stacking-claims.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinCoreModelV2 } from "../../../../../models/cities/nyc/newyorkcitycoin-core-v2.model.ts";
 import { NewYorkCityCoinTokenModelV2 } from "../../../../../models/cities/nyc/newyorkcitycoin-token-v2.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   coreV2 = ctx.models.get(NewYorkCityCoinCoreModelV2, "newyorkcitycoin-core-v2");
   tokenV2 = ctx.models.get(NewYorkCityCoinTokenModelV2, "newyorkcitycoin-token-v2");
   chain.mineEmptyBlock(59000);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[NewYorkCityCoin Core v2]", () => {

--- a/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-stacking.test.ts
+++ b/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-stacking.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, TxReceipt, types, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, TxReceipt, types, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinCoreModelV2 } from "../../../../../models/cities/nyc/newyorkcitycoin-core-v2.model.ts";
 import { NewYorkCityCoinTokenModelV2 } from "../../../../../models/cities/nyc/newyorkcitycoin-token-v2.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   coreV2 = ctx.models.get(NewYorkCityCoinCoreModelV2, "newyorkcitycoin-core-v2");
   tokenV2 = ctx.models.get(NewYorkCityCoinTokenModelV2, "newyorkcitycoin-token-v2");
   chain.mineEmptyBlock(59000);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[NewYorkCityCoin Core v2]", () => {

--- a/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-token-configuration.test.ts
+++ b/tests/cities/nyc/core/core-v2/newyorkcitycoin-core-v2-token-configuration.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, types, run, Chain, beforeEach, it } from "../../../../../deps.ts";
+import { assertEquals, describe, types, run, Chain, beforeEach, it, afterEach } from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinCoreModelV2 } from "../../../../../models/cities/nyc/newyorkcitycoin-core-v2.model.ts";
 
@@ -13,6 +13,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   coreV2 = ctx.models.get(NewYorkCityCoinCoreModelV2, "newyorkcitycoin-core-v2");
   chain.mineEmptyBlock(59000);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[NewYorkCityCoin Core v2]", () => {

--- a/tests/cities/nyc/token/token-v1/newyorkcitycoin-token-send-many.test.ts
+++ b/tests/cities/nyc/token/token-v1/newyorkcitycoin-token-send-many.test.ts
@@ -1,4 +1,4 @@
-import { describe, assertEquals, types, Account, run, Chain, it, beforeEach} from "../../../../../deps.ts";
+import { describe, assertEquals, types, Account, run, Chain, it, beforeEach, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinTokenModel, SendManyRecord } from "../../../../../models/cities/nyc/newyorkcitycoin-token.model.ts";
 
@@ -13,6 +13,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   token = ctx.models.get(NewYorkCityCoinTokenModel, "newyorkcitycoin-token");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[NewYorkCityCoin Token]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/nyc/token/token-v1/newyorkcitycoin-token-sip-010.test.ts
+++ b/tests/cities/nyc/token/token-v1/newyorkcitycoin-token-sip-010.test.ts
@@ -1,4 +1,4 @@
-import { describe, assertEquals, types, run, Chain, it, beforeEach} from "../../../../../deps.ts";
+import { describe, assertEquals, types, run, Chain, it, beforeEach, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinTokenModel } from "../../../../../models/cities/nyc/newyorkcitycoin-token.model.ts";
 
@@ -13,6 +13,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   token = ctx.models.get(NewYorkCityCoinTokenModel, "newyorkcitycoin-token");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[NewYorkCityCoin Token]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/nyc/token/token-v1/newyorkcitycoin-token-utilities.test.ts
+++ b/tests/cities/nyc/token/token-v1/newyorkcitycoin-token-utilities.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, it, beforeEach} from "../../../../../deps.ts";
+import { describe, run, Chain, it, beforeEach, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinCoreModel } from "../../../../../models/cities/nyc/newyorkcitycoin-core.model.ts";
 import { NewYorkCityCoinTokenModel } from "../../../../../models/cities/nyc/newyorkcitycoin-token.model.ts";
@@ -16,6 +16,10 @@ beforeEach(() => {
   core = ctx.models.get(NewYorkCityCoinCoreModel, "newyorkcitycoin-core-v1");
   token = ctx.models.get(NewYorkCityCoinTokenModel, "newyorkcitycoin-token");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[NewYorkCityCoin Token]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/nyc/token/token-v2/newyorkcitycoin-token-v2-send-many.test.ts
+++ b/tests/cities/nyc/token/token-v2/newyorkcitycoin-token-v2-send-many.test.ts
@@ -1,4 +1,4 @@
-import { describe, assertEquals, types, Account, run, Chain, it, beforeEach} from "../../../../../deps.ts";
+import { describe, assertEquals, types, Account, run, Chain, it, beforeEach, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinTokenModelV2, SendManyRecord } from "../../../../../models/cities/nyc/newyorkcitycoin-token-v2.model.ts";
 
@@ -13,6 +13,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   tokenV2 = ctx.models.get(NewYorkCityCoinTokenModelV2, "newyorkcitycoin-token-v2");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[NewYorkCityCoin Token v2]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/nyc/token/token-v2/newyorkcitycoin-token-v2-sip-010.test.ts
+++ b/tests/cities/nyc/token/token-v2/newyorkcitycoin-token-v2-sip-010.test.ts
@@ -1,4 +1,4 @@
-import { describe, assertEquals, types, run, Chain, it, beforeEach} from "../../../../../deps.ts";
+import { describe, assertEquals, types, run, Chain, it, beforeEach, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinTokenModelV2 } from "../../../../../models/cities/nyc/newyorkcitycoin-token-v2.model.ts";
 
@@ -13,6 +13,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   tokenV2 = ctx.models.get(NewYorkCityCoinTokenModelV2, "newyorkcitycoin-token-v2");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[NewYorkCityCoin Token v2]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/nyc/token/token-v2/newyorkcitycoin-token-v2-utilities.test.ts
+++ b/tests/cities/nyc/token/token-v2/newyorkcitycoin-token-v2-utilities.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, it, beforeEach, types, assertEquals} from "../../../../../deps.ts";
+import { describe, run, Chain, it, beforeEach, types, assertEquals, afterEach} from "../../../../../deps.ts";
 import { Accounts, Context } from "../../../../../src/context.ts";
 import { NewYorkCityCoinCoreModelV2 } from "../../../../../models/cities/nyc/newyorkcitycoin-core-v2.model.ts";
 import { NewYorkCityCoinTokenModel } from "../../../../../models/cities/nyc/newyorkcitycoin-token.model.ts";
@@ -19,6 +19,10 @@ beforeEach(() => {
   token = ctx.models.get(NewYorkCityCoinTokenModel, "newyorkcitycoin-token");
   tokenV2 = ctx.models.get(NewYorkCityCoinTokenModelV2, "newyorkcitycoin-token-v2");
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[NewYorkCityCoin Token v2]", () => {
   //////////////////////////////////////////////////

--- a/tests/cities/nyc/upgrade/newyorkcitycoin-core-v1-v2.test.ts
+++ b/tests/cities/nyc/upgrade/newyorkcitycoin-core-v1-v2.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, run, Chain, beforeEach, it, Account, types } from "../../../../deps.ts";
+import { assertEquals, describe, run, Chain, beforeEach, it, Account, types, afterEach, Block } from "../../../../deps.ts";
 import { Accounts, Context } from "../../../../src/context.ts";
 import { NewYorkCityCoinAuthModel } from "../../../../models/cities/nyc/newyorkcitycoin-auth.model.ts";
 import { NewYorkCityCoinCoreModel } from "../../../../models/cities/nyc/newyorkcitycoin-core.model.ts";
@@ -29,6 +29,10 @@ beforeEach(() => {
   tokenV2 = ctx.models.get(NewYorkCityCoinTokenModelV2, "newyorkcitycoin-token-v2");
 });
 
+afterEach(() => {
+  ctx.terminate()
+});
+
 describe("[NewYorkCityCoin Upgrade v1-v2]", () => {
   const jobId = 1;
   const minerCommit = 10;
@@ -42,6 +46,9 @@ describe("[NewYorkCityCoin Upgrade v1-v2]", () => {
   let user2: Account;
   let user3: Account;
   let cityWallet: Account;
+  let block1: Block;
+  let block2: Block;
+  let block3: Block;
 
   beforeEach(() => {
     // setup accounts
@@ -69,21 +76,21 @@ describe("[NewYorkCityCoin Upgrade v1-v2]", () => {
 
     // mine tokens for claim in past
     // block: 37599, user1
-    chain.mineBlock([
+    block1 = chain.mineBlock([
       core.mineTokens(minerCommit * 1000, user1),
       core.mineTokens(minerCommit, user2),
       core.mineTokens(minerCommit, user3),
     ]);
     chain.mineEmptyBlock(100);
     // block: 37700, user2
-    chain.mineBlock([
+    block2 = chain.mineBlock([
       core.mineTokens(minerCommit, user1),
       core.mineTokens(minerCommit * 1000, user2),
       core.mineTokens(minerCommit, user3),
     ]);
     chain.mineEmptyBlock(100);
     // block: 37801, user3
-    chain.mineBlock([
+    block3 = chain.mineBlock([
       core.mineTokens(minerCommit, user1),
       core.mineTokens(minerCommit, user2),
       core.mineTokens(minerCommit * 1000, user3),
@@ -356,9 +363,9 @@ describe("[NewYorkCityCoin Upgrade v1-v2]", () => {
 
   it("claim-mining-reward() succeeds in v1 with block height in the past", () => {
     // arrange
-    const targetBlock1 = 37598;
-    const targetBlock2 = 37699;
-    const targetBlock3 = 37800;
+    const targetBlock1 = block1.height - 1;
+    const targetBlock2 = block2.height - 1;
+    const targetBlock3 = block3.height - 1;
     // act
     const block = chain.mineBlock([
       core.claimMiningReward(targetBlock1, user1),

--- a/tests/tardis/citycoin-tardis-v2.test.ts
+++ b/tests/tardis/citycoin-tardis-v2.test.ts
@@ -1,4 +1,4 @@
-import { describe, assertEquals, types, Account, run, Chain, it, beforeEach} from "../../deps.ts";
+import { describe, assertEquals, types, Account, run, Chain, it, beforeEach, afterEach} from "../../deps.ts";
 import { Accounts, Context } from "../../src/context.ts";
 import { CoreModel } from "../../models/base/core.model.ts";
 import { TokenModel } from "../../models/base/token.model.ts";
@@ -20,6 +20,10 @@ beforeEach(() => {
   tardis = ctx.models.get(TardisModel);
 })
 
+afterEach(() => {
+  ctx.terminate()
+});
+
 describe("[CityCoin Tardis]", () => {
   describe("HISTORICAL ACTIONS", () => {
     describe("get-historical-balance()", () => {
@@ -29,7 +33,7 @@ describe("[CityCoin Tardis]", () => {
         const mintAmount = 100;
 
         chain.mineEmptyBlock(100);
-        chain.mineBlock([
+        let block = chain.mineBlock([
           token.testMint(mintAmount, wallet_1)
         ]);
         chain.mineEmptyBlock(100);
@@ -39,7 +43,7 @@ describe("[CityCoin Tardis]", () => {
 
         // act
         const result1 = tardis.getHistoricalBalance(1, wallet_1).result;
-        const result2 = tardis.getHistoricalBalance(101, wallet_1).result;
+        const result2 = tardis.getHistoricalBalance(block.height, wallet_1).result;
         const result3 = token.getBalance(wallet_1).result;
 
         // assert
@@ -56,7 +60,7 @@ describe("[CityCoin Tardis]", () => {
         const mintAmount = 100;
 
         chain.mineEmptyBlock(100);
-        chain.mineBlock([
+        let block = chain.mineBlock([
           token.testMint(mintAmount, wallet_1)
         ]);
         chain.mineEmptyBlock(100);
@@ -66,7 +70,7 @@ describe("[CityCoin Tardis]", () => {
         
         // act
         const result1 = tardis.getHistoricalSupply(1).result;
-        const result2 = tardis.getHistoricalSupply(101).result;
+        const result2 = tardis.getHistoricalSupply(block.height).result;
         const result3 = token.getTotalSupply().result;
 
         // assert

--- a/tests/utilities/test-utils.test.ts
+++ b/tests/utilities/test-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, run, Chain, beforeEach, it } from "../../deps.ts";
+import { describe, run, Chain, beforeEach, it, afterEach } from "../../deps.ts";
 import { Accounts, Context } from "../../src/context.ts";
 import { TestUtilsModel } from "../../models/utilities/test-utils.model.ts";
 
@@ -13,6 +13,10 @@ beforeEach(()=>{
   accounts = ctx.accounts;
   testUtils = ctx.models.get(TestUtilsModel);
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[CityCoin Test Utils]", () => {
   describe("test-wallet-attack()", () => {

--- a/tests/vote/citycoin-vote-v1.test.ts
+++ b/tests/vote/citycoin-vote-v1.test.ts
@@ -1,4 +1,4 @@
-import { describe, assertEquals, types, run, Chain, it, beforeEach} from "../../deps.ts";
+import { describe, assertEquals, types, run, Chain, it, beforeEach, afterEach} from "../../deps.ts";
 import { Accounts, Context } from "../../src/context.ts";
 import { CoreModel } from "../../models/base/core.model.ts";
 import { TokenModel } from "../../models/base/token.model.ts";
@@ -19,6 +19,10 @@ beforeEach(() => {
   token = ctx.models.get(TokenModel);
   vote = ctx.models.get(VoteModel);
 })
+
+afterEach(() => {
+  ctx.terminate()
+});
 
 describe("[CityCoin Vote]", () => {
   describe("VOTE ACTIONS", () => {

--- a/tests/vrf/citycoin-vrf.test.ts
+++ b/tests/vrf/citycoin-vrf.test.ts
@@ -1,4 +1,4 @@
-import { describe, assertEquals, run, Chain, it, beforeEach} from "../../deps.ts";
+import { describe, assertEquals, run, Chain, it, beforeEach, afterEach} from "../../deps.ts";
 import { Accounts, Context } from "../../src/context.ts";
 import { VrfModel } from "../../models/vrf/vrf.model.ts";
 import { VrfModelV2 } from "../../models/vrf/vrf-v2.model.ts";
@@ -15,6 +15,10 @@ beforeEach(() => {
   accounts = ctx.accounts;
   vrf = ctx.models.get(VrfModel);
   vrfV2 = ctx.models.get(VrfModelV2);
+});
+
+afterEach(() => {
+  ctx.terminate()
 });
 
 describe("[CityCoin VRF]", () => {


### PR DESCRIPTION
New clarinet library has been released and it is not backward compatible therefore some changes must be applied to Citycoins code base.

 1. Contracts are not longer deployed at fixed block. Instead they are batched in group of 25. Because of that `(is-test-env)` has been modified and from now on it validates if contract has been deployed at block <= 5.
 This also showed that some tests are sensitive to such changes and they were failing, because some block heights were hard coded. To fix them I introduced relevant variables in few tests.
 2. New Clarinet version use different deno api and because of that `context.ts` has been updated.
 3. Session termination has been added to Clarinet and it must be executed after each test, therefore I added `terminate` function to `Context` class, and call it in `afterEach`.